### PR TITLE
프로덕션 매물 목록 로딩 버그 수정

### DIFF
--- a/src/app/api/real-estate/route.ts
+++ b/src/app/api/real-estate/route.ts
@@ -87,10 +87,15 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error('[real-estate] API 호출 실패:', error);
-
     const message =
       error instanceof Error ? error.message : '실거래가 조회 중 오류가 발생했습니다.';
+    const stack = error instanceof Error ? error.stack : undefined;
+
+    console.error('[real-estate] API 호출 실패:', {
+      message,
+      stack,
+      params: { regionCode, dealYM, type },
+    });
 
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/properties/page.tsx
+++ b/src/app/properties/page.tsx
@@ -29,7 +29,13 @@ async function fetchPropertiesForRegion(
 ): Promise<RealEstateTransaction[]> {
   const url = `/api/real-estate?regionCode=${regionCode}&dealYM=${dealYM}&type=${fetchType}`;
   const res = await fetch(url);
-  if (!res.ok) return [];
+  if (!res.ok) {
+    const errorBody = await res.text().catch(() => '(응답 읽기 실패)');
+    console.error(
+      `[properties] API 호출 실패: status=${res.status}, regionCode=${regionCode}, dealYM=${dealYM}, type=${fetchType}, body=${errorBody.substring(0, 300)}`
+    );
+    return [];
+  }
   const json = await res.json();
   return json.data ?? [];
 }

--- a/src/lib/api/fss.ts
+++ b/src/lib/api/fss.ts
@@ -165,6 +165,8 @@ async function fetchFssLoanProducts(
     });
 
     if (!response.ok) {
+      const body = await response.text().catch(() => '(응답 본문 읽기 실패)');
+      console.error(`[fss] API 요청 실패: status=${response.status}, endpoint=${endpoint}, body=${body.substring(0, 500)}`);
       throw new Error(
         `금감원 API 요청 실패: ${response.status} ${response.statusText}`,
       );

--- a/src/lib/api/molit.ts
+++ b/src/lib/api/molit.ts
@@ -37,8 +37,9 @@ const xmlParser = new XMLParser({
   trimValues: true,
 });
 
-/** 새 API 영문 필드명 */
+/** 새 API 영문 필드명 + 구 API 한글 필드명 폴백 */
 interface RawItem {
+  // 영문 필드명 (apis.data.go.kr)
   dealAmount?: string;
   buildYear?: number;
   dealYear?: number;
@@ -55,6 +56,23 @@ interface RawItem {
   // 연립다세대/오피스텔용
   mhouseNm?: string;     // 연립다세대명
   offiNm?: string;       // 오피스텔명
+
+  // 한글 필드명 폴백 (구 openapi.molit.go.kr)
+  '거래금액'?: string;
+  '건축년도'?: number;
+  '년'?: number;
+  '월'?: number;
+  '일'?: number;
+  '법정동'?: string;
+  '아파트'?: string;
+  '연립다세대'?: string;
+  '오피스텔'?: string;
+  '전용면적'?: number;
+  '층'?: number;
+  '지번'?: string;
+  '지역코드'?: string;
+  '해제여부'?: string;
+  '거래유형'?: string;
 }
 
 /**
@@ -71,19 +89,19 @@ function parseDealAmount(raw: string | undefined): number {
  */
 function mapRawItem(item: RawItem, fallbackRegionCode: string): RealEstateTransaction {
   return {
-    dealAmount: parseDealAmount(item.dealAmount),
-    buildYear: Number(item.buildYear) || 0,
-    dealYear: Number(item.dealYear) || 0,
-    dealMonth: Number(item.dealMonth) || 0,
-    dealDay: Number(item.dealDay) || 0,
-    dong: String(item.umdNm ?? '').trim(),
-    aptName: String(item.aptNm ?? item.mhouseNm ?? item.offiNm ?? '').trim(),
-    area: Number(item.excluUseAr) || 0,
-    floor: Number(item.floor) || 0,
-    jibun: String(item.jibun ?? '').trim(),
-    regionCode: String(item.sggCd ?? fallbackRegionCode).trim(),
-    cancelDealType: String(item.cdealType ?? '').trim(),
-    dealType: String(item.dealingGbn ?? '').trim(),
+    dealAmount: parseDealAmount(item.dealAmount ?? item['거래금액']),
+    buildYear: Number(item.buildYear ?? item['건축년도']) || 0,
+    dealYear: Number(item.dealYear ?? item['년']) || 0,
+    dealMonth: Number(item.dealMonth ?? item['월']) || 0,
+    dealDay: Number(item.dealDay ?? item['일']) || 0,
+    dong: String(item.umdNm ?? item['법정동'] ?? '').trim(),
+    aptName: String(item.aptNm ?? item['아파트'] ?? item.mhouseNm ?? item['연립다세대'] ?? item.offiNm ?? item['오피스텔'] ?? '').trim(),
+    area: Number(item.excluUseAr ?? item['전용면적']) || 0,
+    floor: Number(item.floor ?? item['층']) || 0,
+    jibun: String(item.jibun ?? item['지번'] ?? '').trim(),
+    regionCode: String(item.sggCd ?? item['지역코드'] ?? fallbackRegionCode).trim(),
+    cancelDealType: String(item.cdealType ?? item['해제여부'] ?? '').trim(),
+    dealType: String(item.dealingGbn ?? item['거래유형'] ?? '').trim(),
   };
 }
 
@@ -126,7 +144,15 @@ async function fetchMolitData(
     return MOCK_APT_TRADE;
   }
 
-  const requestUrl = `${API_CONFIG.MOLIT.BASE_URL}${endpoint}?serviceKey=${apiKey}&LAWD_CD=${regionCode}&DEAL_YMD=${dealYM}&numOfRows=1000`;
+  // URL 객체를 사용하여 API 키의 특수문자(+, =, / 등)를 안전하게 인코딩
+  const url = new URL(`${API_CONFIG.MOLIT.BASE_URL}${endpoint}`);
+  url.searchParams.set('serviceKey', apiKey);
+  url.searchParams.set('LAWD_CD', regionCode);
+  url.searchParams.set('DEAL_YMD', dealYM);
+  url.searchParams.set('numOfRows', '1000');
+  const requestUrl = url.toString();
+
+  console.log(`[molit] API 요청: endpoint=${endpoint}, regionCode=${regionCode}, dealYM=${dealYM}`);
 
   const response = await fetch(requestUrl, {
     next: { revalidate: 3600 },
@@ -134,13 +160,25 @@ async function fetchMolitData(
   });
 
   if (!response.ok) {
+    const body = await response.text().catch(() => '(응답 본문 읽기 실패)');
+    console.error(`[molit] API 요청 실패: status=${response.status}, body=${body.substring(0, 500)}`);
     throw new Error(
       `국토부 API 요청 실패: ${response.status} ${response.statusText}`,
     );
   }
 
   const xml = await response.text();
-  return parseXmlResponse(xml, regionCode);
+
+  // XML 응답에 에러 코드가 포함되어 있는지 확인
+  if (xml.includes('<resultCode>') && !xml.includes('<resultCode>00</resultCode>')) {
+    console.error(`[molit] API 응답 에러: ${xml.substring(0, 500)}`);
+    throw new Error(`국토부 API 응답 오류 (endpoint: ${endpoint})`);
+  }
+
+  const results = parseXmlResponse(xml, regionCode);
+  console.log(`[molit] 조회 완료: ${results.length}건 (regionCode=${regionCode}, dealYM=${dealYM})`);
+
+  return results;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- API Key URL 인코딩 방식을 템플릿 리터럴에서 `URL` 객체 + `searchParams`로 복원하여 특수문자(`+`, `=`, `/`) 안전 처리
- 공공데이터포털 API 응답 필드명이 영문/한글 어느 쪽이든 파싱 가능하도록 한글 필드명 폴백 추가
- XML 응답의 `resultCode` 검증으로 API 레벨 에러 조기 감지
- 프로덕션 디버깅을 위한 상세 에러 로깅 추가 (molit, fss, real-estate route, properties page)

Closes #39

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `src/lib/api/molit.ts` | URL 인코딩 수정, 한글 필드명 폴백, 응답 에러코드 검증, 로깅 |
| `src/app/api/real-estate/route.ts` | catch 블록 상세 에러 로깅 |
| `src/app/properties/page.tsx` | API 실패 시 상세 로깅 |
| `src/lib/api/fss.ts` | API 실패 시 응답 본문 로깅 |

## Test plan
- [ ] 로컬에서 매물 목록 정상 조회 확인
- [ ] Vercel 프리뷰 배포에서 매물 목록 정상 조회 확인
- [ ] API 키에 특수문자 포함 시 정상 동작 확인
- [ ] 잘못된 API 키로 요청 시 에러 메시지가 콘솔에 상세 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)