### PR TITLE
매물 목록 로딩 최적화 - 서버 일괄 조회 + 로딩 프로그레스 UI

### DIFF
--- a/src/app/api/real-estate/batch/route.ts
+++ b/src/app/api/real-estate/batch/route.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// 매물 일괄 조회 API Route
+// 클라이언트에서 1회 호출 → 서버에서 전체 병렬 처리
+// =============================================================================
+
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchPropertiesBatch } from '@/lib/api/batchProperties';
+
+interface BatchRequestBody {
+  regionCodes: string[];
+  types: ('apt' | 'villa' | 'officetel')[];
+  months: number;
+  maxPrice: number;
+}
+
+const VALID_TYPES = new Set(['apt', 'villa', 'officetel']);
+
+export async function POST(request: NextRequest) {
+  let body: BatchRequestBody;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: '유효한 JSON 본문이 필요합니다.' },
+      { status: 400 },
+    );
+  }
+
+  const { regionCodes, types, months, maxPrice } = body;
+
+  // 유효성 검증
+  if (!Array.isArray(regionCodes) || regionCodes.length === 0) {
+    return NextResponse.json(
+      { error: 'regionCodes 배열이 필요합니다.' },
+      { status: 400 },
+    );
+  }
+
+  if (regionCodes.length > 10) {
+    return NextResponse.json(
+      { error: 'regionCodes는 최대 10개까지 지원합니다.' },
+      { status: 400 },
+    );
+  }
+
+  if (regionCodes.some((code) => !/^\d{5}$/.test(code))) {
+    return NextResponse.json(
+      { error: 'regionCode는 5자리 숫자여야 합니다.' },
+      { status: 400 },
+    );
+  }
+
+  if (!Array.isArray(types) || types.length === 0 || types.some((t) => !VALID_TYPES.has(t))) {
+    return NextResponse.json(
+      { error: 'types는 apt, villa, officetel 중 하나여야 합니다.' },
+      { status: 400 },
+    );
+  }
+
+  if (typeof months !== 'number' || months < 1 || months > 12) {
+    return NextResponse.json(
+      { error: 'months는 1~12 사이 숫자여야 합니다.' },
+      { status: 400 },
+    );
+  }
+
+  if (typeof maxPrice !== 'number' || maxPrice <= 0) {
+    return NextResponse.json(
+      { error: 'maxPrice는 양수여야 합니다.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await fetchPropertiesBatch({
+      regionCodes,
+      types,
+      monthCount: months,
+      maxPrice,
+    });
+
+    return NextResponse.json({
+      data: result.properties,
+      meta: result.meta,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : '매물 일괄 조회 중 오류가 발생했습니다.';
+
+    console.error('[batch-route] 오류:', message);
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/properties/page.tsx
+++ b/src/app/properties/page.tsx
@@ -2,43 +2,12 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { StepIndicator, Button, Card, Skeleton } from "@/components/common";
+import { StepIndicator, Button } from "@/components/common";
 import { useHousePinStore } from "@/store/useHousePinStore";
-import { formatToKoreanWon, getRecentMonths } from "@/lib/utils/format";
-import {
-  filterByAffordability,
-  toProperty,
-} from "@/lib/utils/propertyFilter";
-import type { RealEstateTransaction } from "@/lib/api/molit";
+import { formatToKoreanWon } from "@/lib/utils/format";
 import type { Property } from "@/types";
 import PropertyView from "@/components/properties/PropertyView";
-
-type FetchType = "apt" | "villa" | "officetel";
-type PropertyType = "apartment" | "villa" | "officetel";
-
-const FETCH_TYPES: { type: FetchType; propertyType: PropertyType }[] = [
-  { type: "apt", propertyType: "apartment" },
-  { type: "villa", propertyType: "villa" },
-  { type: "officetel", propertyType: "officetel" },
-];
-
-async function fetchPropertiesForRegion(
-  regionCode: string,
-  dealYM: string,
-  fetchType: FetchType
-): Promise<RealEstateTransaction[]> {
-  const url = `/api/real-estate?regionCode=${regionCode}&dealYM=${dealYM}&type=${fetchType}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    const errorBody = await res.text().catch(() => '(응답 읽기 실패)');
-    console.error(
-      `[properties] API 호출 실패: status=${res.status}, regionCode=${regionCode}, dealYM=${dealYM}, type=${fetchType}, body=${errorBody.substring(0, 300)}`
-    );
-    return [];
-  }
-  const json = await res.json();
-  return json.data ?? [];
-}
+import LoadingProgress from "@/components/properties/LoadingProgress";
 
 export default function PropertiesPage() {
   const router = useRouter();
@@ -61,38 +30,26 @@ export default function PropertiesPage() {
     setError(null);
 
     try {
-      const months = getRecentMonths(6);
-      const allProperties: Property[] = [];
-
-      // 각 지역 + 각 월 + 각 매물 유형 조회
-      for (const region of selectedRegions) {
-        for (const { type, propertyType } of FETCH_TYPES) {
-          const promises = months.map((dealYM) =>
-            fetchPropertiesForRegion(region.code, dealYM, type)
-          );
-          const results = await Promise.all(promises);
-          const allTransactions = results.flat();
-
-          // 구매력 범위 필터링
-          const filtered = filterByAffordability({
-            transactions: allTransactions,
-            maxPrice: affordablePrice,
-          });
-
-          const mapped = filtered.map((tx) => toProperty(tx, propertyType));
-          allProperties.push(...mapped);
-        }
-      }
-
-      // 최신순 정렬
-      allProperties.sort((a, b) => {
-        if (a.dealYear !== b.dealYear) return b.dealYear - a.dealYear;
-        if (a.dealMonth !== b.dealMonth) return b.dealMonth - a.dealMonth;
-        return b.dealDay - a.dealDay;
+      const res = await fetch("/api/real-estate/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          regionCodes: selectedRegions.map((r) => r.code),
+          types: ["apt", "villa", "officetel"],
+          months: 3,
+          maxPrice: affordablePrice,
+        }),
       });
 
-      setLocalProperties(allProperties);
-      setProperties(allProperties);
+      if (!res.ok) {
+        throw new Error("매물 데이터를 불러오는 중 오류가 발생했습니다.");
+      }
+
+      const json = await res.json();
+      const properties = (json.data ?? []) as Property[];
+
+      setLocalProperties(properties);
+      setProperties(properties);
     } catch (err) {
       console.error("[properties] 매물 조회 실패:", err);
       setError("매물 데이터를 불러오는 중 오류가 발생했습니다.");
@@ -140,20 +97,7 @@ export default function PropertiesPage() {
       </div>
 
       {/* 로딩 상태 */}
-      {loading && (
-        <div className="flex flex-col gap-3">
-          {[1, 2, 3].map((i) => (
-            <Card key={i}>
-              <div className="flex flex-col gap-3">
-                <Skeleton height="20px" width="60%" />
-                <Skeleton height="24px" width="40%" />
-                <Skeleton height="16px" width="80%" />
-                <Skeleton height="14px" width="30%" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      )}
+      {loading && <LoadingProgress />}
 
       {/* 에러 상태 */}
       {!loading && error && (

--- a/src/components/properties/LoadingProgress.tsx
+++ b/src/components/properties/LoadingProgress.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card } from "@/components/common";
+
+const LOADING_MESSAGES = [
+  "아파트 매물 검색 중...",
+  "빌라 매물 검색 중...",
+  "오피스텔 매물 검색 중...",
+  "가격 비교 중...",
+  "거의 다 됐어요!",
+];
+
+interface LoadingProgressProps {
+  className?: string;
+}
+
+export default function LoadingProgress({ className }: LoadingProgressProps) {
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setMessageIndex((prev) =>
+        prev < LOADING_MESSAGES.length - 1 ? prev + 1 : prev
+      );
+    }, 2500);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const progress = ((messageIndex + 1) / LOADING_MESSAGES.length) * 100;
+
+  return (
+    <div className={className}>
+      <Card>
+        <div className="flex flex-col items-center gap-5 py-8">
+          {/* 스피너 */}
+          <div className="relative h-10 w-10">
+            <div
+              className="absolute inset-0 rounded-full border-[3px] border-border"
+              aria-hidden
+            />
+            <div
+              className="absolute inset-0 animate-spin rounded-full border-[3px] border-transparent border-t-accent"
+              role="status"
+            />
+          </div>
+
+          {/* 메시지 */}
+          <p className="text-base font-medium text-secondary transition-opacity duration-300">
+            {LOADING_MESSAGES[messageIndex]}
+          </p>
+
+          {/* 프로그레스 바 */}
+          <div className="h-1 w-48 overflow-hidden rounded-full bg-surface">
+            <div
+              className="h-full rounded-full bg-accent transition-all duration-500 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/api/batchProperties.test.ts
+++ b/src/lib/api/batchProperties.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { RealEstateTransaction } from '@/lib/api/molit';
+
+// 모킹
+vi.mock('@/lib/api/molit', () => ({
+  fetchAptTrade: vi.fn(),
+  fetchVillaTrade: vi.fn(),
+  fetchOfficeTrade: vi.fn(),
+}));
+
+vi.mock('@/lib/api/kakao', () => ({
+  batchGeocode: vi.fn().mockResolvedValue(new Map()),
+  buildAddress: vi.fn(
+    (sigungu: string, dong: string, jibun: string) =>
+      `${sigungu} ${dong} ${jibun}`,
+  ),
+}));
+
+vi.mock('@/constants/regions', () => ({
+  getRegionBySigunguCode: vi.fn().mockReturnValue({
+    sido: '서울특별시',
+    sigungu: '강남구',
+  }),
+}));
+
+import { fetchAptTrade, fetchVillaTrade, fetchOfficeTrade } from '@/lib/api/molit';
+import { fetchPropertiesBatch } from './batchProperties';
+
+// =============================================================================
+// 테스트 데이터
+// =============================================================================
+
+function makeTx(overrides: Partial<RealEstateTransaction> = {}): RealEstateTransaction {
+  return {
+    dealAmount: 80000,
+    buildYear: 2020,
+    dealYear: 2026,
+    dealMonth: 3,
+    dealDay: 10,
+    dong: '역삼동',
+    aptName: '테스트아파트',
+    area: 59.9,
+    floor: 5,
+    jibun: '725',
+    regionCode: '11680',
+    cancelDealType: '',
+    dealType: '중개거래',
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// 테스트
+// =============================================================================
+
+describe('fetchPropertiesBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 기본: 모든 API가 빈 배열 반환
+    vi.mocked(fetchAptTrade).mockResolvedValue([]);
+    vi.mocked(fetchVillaTrade).mockResolvedValue([]);
+    vi.mocked(fetchOfficeTrade).mockResolvedValue([]);
+  });
+
+  it('구매력 범위 내 매물만 반환한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([
+      makeTx({ dealAmount: 50000, aptName: '저렴한매물' }),
+      makeTx({ dealAmount: 150000, aptName: '비싼매물' }),
+    ]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 100000,
+    });
+
+    expect(result.properties).toHaveLength(1);
+    expect(result.properties[0].name).toBe('저렴한매물');
+  });
+
+  it('거래 취소 건을 제외한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([
+      makeTx({ aptName: '정상거래' }),
+      makeTx({ aptName: '취소거래', cancelDealType: 'O' }),
+    ]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties).toHaveLength(1);
+    expect(result.properties[0].name).toBe('정상거래');
+  });
+
+  it('여러 지역을 동시에 처리한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([makeTx()]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680', '11650'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    // 2지역 × 1유형 × 1개월 = 2회 호출
+    expect(fetchAptTrade).toHaveBeenCalledTimes(2);
+    expect(result.properties).toHaveLength(2);
+  });
+
+  it('여러 유형을 동시에 처리한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([makeTx({ aptName: '아파트' })]);
+    vi.mocked(fetchVillaTrade).mockResolvedValue([makeTx({ aptName: '빌라' })]);
+    vi.mocked(fetchOfficeTrade).mockResolvedValue([makeTx({ aptName: '오피스텔' })]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt', 'villa', 'officetel'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties).toHaveLength(3);
+    const types = result.properties.map((p) => p.propertyType);
+    expect(types).toContain('apartment');
+    expect(types).toContain('villa');
+    expect(types).toContain('officetel');
+  });
+
+  it('API 호출 실패 시 다른 결과는 유지한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([makeTx({ aptName: '성공매물' })]);
+    vi.mocked(fetchVillaTrade).mockRejectedValue(new Error('API 오류'));
+    vi.mocked(fetchOfficeTrade).mockResolvedValue([]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt', 'villa', 'officetel'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties).toHaveLength(1);
+    expect(result.properties[0].name).toBe('성공매물');
+    expect(result.meta.failedCalls).toBe(1);
+  });
+
+  it('최신순으로 정렬된 결과를 반환한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([
+      makeTx({ aptName: '오래된매물', dealYear: 2025, dealMonth: 12, dealDay: 1 }),
+      makeTx({ aptName: '최신매물', dealYear: 2026, dealMonth: 3, dealDay: 15 }),
+      makeTx({ aptName: '중간매물', dealYear: 2026, dealMonth: 1, dealDay: 20 }),
+    ]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties[0].name).toBe('최신매물');
+    expect(result.properties[1].name).toBe('중간매물');
+    expect(result.properties[2].name).toBe('오래된매물');
+  });
+
+  it('cancelDealType Y도 제외한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([
+      makeTx({ aptName: '정상', cancelDealType: '' }),
+      makeTx({ aptName: '취소Y', cancelDealType: 'Y' }),
+    ]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties).toHaveLength(1);
+    expect(result.properties[0].name).toBe('정상');
+  });
+
+  it('모든 API 호출이 실패해도 빈 결과를 반환한다', async () => {
+    vi.mocked(fetchAptTrade).mockRejectedValue(new Error('실패'));
+    vi.mocked(fetchVillaTrade).mockRejectedValue(new Error('실패'));
+    vi.mocked(fetchOfficeTrade).mockRejectedValue(new Error('실패'));
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt', 'villa', 'officetel'],
+      monthCount: 1,
+      maxPrice: 999999,
+    });
+
+    expect(result.properties).toHaveLength(0);
+    expect(result.meta.failedCalls).toBe(3);
+  });
+
+  it('meta 정보를 정확히 반환한다', async () => {
+    vi.mocked(fetchAptTrade).mockResolvedValue([
+      makeTx({ dealAmount: 50000 }),
+      makeTx({ dealAmount: 150000 }),
+    ]);
+
+    const result = await fetchPropertiesBatch({
+      regionCodes: ['11680'],
+      types: ['apt'],
+      monthCount: 1,
+      maxPrice: 100000,
+    });
+
+    expect(result.meta.totalFetched).toBe(2);
+    expect(result.meta.totalFiltered).toBe(1);
+    expect(result.meta.failedCalls).toBe(0);
+  });
+});

--- a/src/lib/api/batchProperties.ts
+++ b/src/lib/api/batchProperties.ts
@@ -1,0 +1,181 @@
+// =============================================================================
+// 매물 일괄 조회 로직
+// 여러 지역/유형/월을 서버에서 병렬로 처리
+// =============================================================================
+
+import {
+  fetchAptTrade,
+  fetchVillaTrade,
+  fetchOfficeTrade,
+} from '@/lib/api/molit';
+import type { RealEstateTransaction } from '@/lib/api/molit';
+import { batchGeocode, buildAddress } from '@/lib/api/kakao';
+import { getRegionBySigunguCode } from '@/constants/regions';
+import { getRecentMonths } from '@/lib/utils/format';
+import { filterByAffordability, toProperty } from '@/lib/utils/propertyFilter';
+import { parallelLimit } from '@/lib/utils/concurrency';
+import type { Property } from '@/types';
+
+// =============================================================================
+// 타입 정의
+// =============================================================================
+
+type TradeType = 'apt' | 'villa' | 'officetel';
+type PropertyType = 'apartment' | 'villa' | 'officetel';
+
+const TRADE_TYPE_MAP: Record<TradeType, PropertyType> = {
+  apt: 'apartment',
+  villa: 'villa',
+  officetel: 'officetel',
+};
+
+const FETCH_FN_MAP: Record<
+  TradeType,
+  (regionCode: string, dealYM: string) => Promise<RealEstateTransaction[]>
+> = {
+  apt: fetchAptTrade,
+  villa: fetchVillaTrade,
+  officetel: fetchOfficeTrade,
+};
+
+export interface BatchFetchParams {
+  regionCodes: string[];
+  types: TradeType[];
+  monthCount: number;
+  maxPrice: number;
+}
+
+export interface BatchFetchResult {
+  properties: Property[];
+  meta: {
+    totalFetched: number;
+    totalFiltered: number;
+    failedCalls: number;
+  };
+}
+
+// =============================================================================
+// 메인 함수
+// =============================================================================
+
+const CONCURRENCY_LIMIT = 10;
+
+export async function fetchPropertiesBatch(
+  params: BatchFetchParams,
+): Promise<BatchFetchResult> {
+  const { regionCodes, types, monthCount, maxPrice } = params;
+  const months = getRecentMonths(monthCount);
+
+  // 모든 조합을 태스크 배열로 생성
+  const tasks: (() => Promise<{
+    transactions: RealEstateTransaction[];
+    type: TradeType;
+  }>)[] = [];
+
+  for (const regionCode of regionCodes) {
+    for (const type of types) {
+      for (const dealYM of months) {
+        const fetchFn = FETCH_FN_MAP[type];
+        tasks.push(async () => ({
+          transactions: await fetchFn(regionCode, dealYM),
+          type,
+        }));
+      }
+    }
+  }
+
+  console.log(`[batch] ${tasks.length}개 API 호출 시작 (concurrency=${CONCURRENCY_LIMIT})`);
+
+  // 병렬 실행 (동시성 제한)
+  const results = await parallelLimit(tasks, CONCURRENCY_LIMIT);
+
+  // 결과 집계
+  let totalFetched = 0;
+  let failedCalls = 0;
+  const allTransactions: { tx: RealEstateTransaction; type: TradeType }[] = [];
+
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      const { transactions, type } = result.value;
+      // 거래 취소 건 제외
+      const valid = transactions.filter(
+        (tx) => tx.cancelDealType !== 'O' && tx.cancelDealType !== 'Y',
+      );
+      totalFetched += valid.length;
+      for (const tx of valid) {
+        allTransactions.push({ tx, type });
+      }
+    } else {
+      failedCalls++;
+      console.warn('[batch] API 호출 실패:', result.reason);
+    }
+  }
+
+  // 구매력 필터링
+  const filtered = filterByAffordability({
+    transactions: allTransactions.map((item) => item.tx),
+    maxPrice,
+  });
+
+  // 필터링된 거래의 타입 매핑 유지 (인덱스 기반)
+  const filteredSet = new Set(filtered);
+  const filteredWithType = allTransactions.filter((item) =>
+    filteredSet.has(item.tx),
+  );
+
+  // 지오코딩
+  const geocodeTargets = filteredWithType.map((item) => {
+    const regionInfo = getRegionBySigunguCode(item.tx.regionCode);
+    const sigunguName = regionInfo
+      ? `${regionInfo.sido} ${regionInfo.sigungu}`
+      : '';
+    return {
+      address: buildAddress(sigunguName, item.tx.dong, item.tx.jibun),
+    };
+  });
+
+  let coordsMap: Map<string, { lat: number; lng: number }>;
+  try {
+    coordsMap = await batchGeocode(geocodeTargets);
+  } catch (err) {
+    console.warn('[batch] 지오코딩 실패, 좌표 없이 진행:', err);
+    coordsMap = new Map();
+  }
+
+  // Property 변환 + 좌표 매핑
+  const properties: Property[] = filteredWithType.map((item) => {
+    const regionInfo = getRegionBySigunguCode(item.tx.regionCode);
+    const sigunguName = regionInfo
+      ? `${regionInfo.sido} ${regionInfo.sigungu}`
+      : '';
+    const address = buildAddress(sigunguName, item.tx.dong, item.tx.jibun);
+    const coords = coordsMap.get(address);
+    const propertyType = TRADE_TYPE_MAP[item.type];
+
+    const txWithCoords = coords
+      ? { ...item.tx, lat: coords.lat, lng: coords.lng }
+      : item.tx;
+
+    return toProperty(txWithCoords, propertyType);
+  });
+
+  // 최신순 정렬
+  properties.sort((a, b) => {
+    if (a.dealYear !== b.dealYear) return b.dealYear - a.dealYear;
+    if (a.dealMonth !== b.dealMonth) return b.dealMonth - a.dealMonth;
+    return b.dealDay - a.dealDay;
+  });
+
+  console.log(
+    `[batch] 완료: ${totalFetched}건 조회 → ${properties.length}건 필터링, 실패 ${failedCalls}건`,
+  );
+
+  return {
+    properties,
+    meta: {
+      totalFetched,
+      totalFiltered: properties.length,
+      failedCalls,
+    },
+  };
+}

--- a/src/lib/utils/concurrency.test.ts
+++ b/src/lib/utils/concurrency.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import { parallelLimit } from './concurrency';
+
+describe('parallelLimit', () => {
+  it('모든 태스크의 결과를 반환한다', async () => {
+    const tasks = [
+      () => Promise.resolve(1),
+      () => Promise.resolve(2),
+      () => Promise.resolve(3),
+    ];
+
+    const results = await parallelLimit(tasks, 2);
+
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => (r as PromiseFulfilledResult<number>).value)).toEqual([1, 2, 3]);
+  });
+
+  it('빈 태스크 배열을 처리한다', async () => {
+    const results = await parallelLimit([], 5);
+    expect(results).toEqual([]);
+  });
+
+  it('실패한 태스크를 rejected로 반환한다', async () => {
+    const tasks = [
+      () => Promise.resolve('ok'),
+      () => Promise.reject(new Error('fail')),
+      () => Promise.resolve('ok2'),
+    ];
+
+    const results = await parallelLimit(tasks, 3);
+
+    expect(results[0].status).toBe('fulfilled');
+    expect(results[1].status).toBe('rejected');
+    expect(results[2].status).toBe('fulfilled');
+  });
+
+  it('동시성 제한을 준수한다', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const makeTask = () => async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((r) => setTimeout(r, 10));
+      concurrent--;
+      return true;
+    };
+
+    const tasks = Array.from({ length: 6 }, makeTask);
+    await parallelLimit(tasks, 2);
+
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+
+  it('limit가 0 이하이면 에러를 던진다', async () => {
+    const tasks = [() => Promise.resolve(1)];
+    await expect(parallelLimit(tasks, 0)).rejects.toThrow('limit must be >= 1');
+    await expect(parallelLimit(tasks, -1)).rejects.toThrow('limit must be >= 1');
+  });
+
+  it('limit가 태스크 수보다 큰 경우 정상 동작한다', async () => {
+    const tasks = [() => Promise.resolve(1), () => Promise.resolve(2)];
+    const results = await parallelLimit(tasks, 100);
+
+    expect(results).toHaveLength(2);
+  });
+
+  it('결과 순서가 태스크 순서와 일치한다', async () => {
+    const tasks = [
+      () => new Promise<string>((r) => setTimeout(() => r('slow'), 30)),
+      () => new Promise<string>((r) => setTimeout(() => r('fast'), 5)),
+    ];
+
+    const results = await parallelLimit(tasks, 2);
+
+    expect((results[0] as PromiseFulfilledResult<string>).value).toBe('slow');
+    expect((results[1] as PromiseFulfilledResult<string>).value).toBe('fast');
+  });
+});

--- a/src/lib/utils/concurrency.ts
+++ b/src/lib/utils/concurrency.ts
@@ -1,0 +1,22 @@
+/**
+ * 동시성 제한 유틸리티
+ * Promise 배열을 최대 limit개씩 병렬 실행
+ */
+export async function parallelLimit<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number,
+): Promise<PromiseSettledResult<T>[]> {
+  if (limit < 1) {
+    throw new Error('parallelLimit: limit must be >= 1');
+  }
+
+  const results: PromiseSettledResult<T>[] = [];
+
+  for (let i = 0; i < tasks.length; i += limit) {
+    const batch = tasks.slice(i, i + limit);
+    const batchResults = await Promise.allSettled(batch.map((fn) => fn()));
+    results.push(...batchResults);
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- 클라이언트 N×3×6 순차 API 호출 → **서버 1회 POST 병렬 처리**로 변경 (`/api/real-estate/batch`)
- 조회 기간 6개월 → 3개월로 축소 (API 호출 50% 감소)
- 스켈레톤 카드 → **프로그레스 바 + 단계별 메시지 스피너**로 교체
- 개별 API 실패 허용 (`Promise.allSettled`), 지오코딩 실패 시 좌표 없이 반환
- 동시성 제한 유틸 (`parallelLimit`), 지역 최대 10개 제한

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/app/api/real-estate/batch/route.ts` | 신규 - Batch POST API 라우트 |
| `src/lib/api/batchProperties.ts` | 신규 - 서버 일괄 조회 로직 |
| `src/lib/utils/concurrency.ts` | 신규 - 동시성 제한 유틸 |
| `src/components/properties/LoadingProgress.tsx` | 신규 - 로딩 프로그레스 UI |
| `src/app/properties/page.tsx` | 수정 - 1회 POST 호출로 단순화 |
| 테스트 2개 | 신규 - 16개 테스트 추가 |

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 새 테스트 16개 전부 통과 (concurrency 7개 + batchProperties 9개)
- [x] 기존 테스트 영향 없음 (validation.test.ts 2개 실패는 기존 이슈)
- [ ] 실제 API 키로 매물 로딩 E2E 확인
- [ ] Vercel 프리뷰 배포 후 로딩 UX 확인

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)