### PR TITLE
결과 페이지 IA 리팩토링 Phase 1 - 카드 통합 + 접기/펼치기 + 상태 영속화

### DIFF
--- a/src/app/properties/[id]/page.tsx
+++ b/src/app/properties/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/common";
-import { useHousePinStore } from "@/store/useHousePinStore";
+import { useHousePinStore, useHasHydrated } from "@/store/useHousePinStore";
 import { findPropertyBySlug } from "@/lib/utils/property";
 import { isLiveSlug, parseLiveSlug } from "@/lib/utils/listingAdapter";
 import { calculatePropertyAffordability } from "@/lib/calculation/affordability";
@@ -27,11 +27,21 @@ export default function PropertyDetailPage({
   const { id } = use(params);
   const router = useRouter();
 
+  const hasHydrated = useHasHydrated();
   const loanResult = useHousePinStore((s) => s.loanResult);
   const assetInput = useHousePinStore((s) => s.assetInput);
   const properties = useHousePinStore((s) => s.properties);
   const liveListings = useHousePinStore((s) => s.liveListings);
   const affordablePrice = loanResult?.affordablePrice ?? 0;
+
+  // 하이드레이션 완료 전 로딩 표시
+  if (!hasHydrated) {
+    return (
+      <main className="flex items-center justify-center py-24">
+        <p className="text-secondary">불러오는 중...</p>
+      </main>
+    );
+  }
 
   // 가드: 대출 계산 결과 없음
   if (!loanResult) {

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { StepIndicator, Button } from "@/components/common";
-import { useHousePinStore } from "@/store/useHousePinStore";
+import {
+  StepIndicator,
+  Button,
+  CollapsibleCard,
+} from "@/components/common";
+import { useHousePinStore, useHasHydrated } from "@/store/useHousePinStore";
 import { calculateLoanResult } from "@/lib/calculation";
 import AffordabilityCard from "@/components/result/AffordabilityCard";
-import PolicyLoanCard from "@/components/result/PolicyLoanCard";
-import PolicyBenefitCard from "@/components/result/PolicyBenefitCard";
-import LoanSlider from "@/components/result/LoanSlider";
-import BankComparisonTable from "@/components/result/BankComparisonTable";
+import PolicyCard from "@/components/result/PolicyCard";
+import LoanExplorer from "@/components/result/LoanExplorer";
 import ScenarioComparisonCard from "@/components/result/ScenarioComparisonCard";
 import UpgradeSimulatorCard from "@/components/result/UpgradeSimulatorCard";
 
@@ -23,10 +25,12 @@ export default function ResultPage() {
   const setLoanResult = useHousePinStore((s) => s.setLoanResult);
   const setCurrentStep = useHousePinStore((s) => s.setCurrentStep);
 
-  const [loanAmount, setLoanAmount] = useState(0);
+  const hasHydrated = useHasHydrated();
 
   // 대출 계산 실행
   useEffect(() => {
+    if (!hasHydrated) return;
+
     // 자산 정보가 없으면 입력 페이지로 리다이렉트
     if (assetInput.annualIncome <= 0 && assetInput.ownCapital <= 0) {
       router.replace("/input");
@@ -35,13 +39,8 @@ export default function ResultPage() {
 
     const result = calculateLoanResult(assetInput, DEFAULT_MARKET_RATE);
     setLoanResult(result);
-    setLoanAmount(result.finalLoanLimit);
     setCurrentStep(2);
-  }, [assetInput, setLoanResult, setCurrentStep, router]);
-
-  const handleLoanAmountChange = useCallback((amount: number) => {
-    setLoanAmount(amount);
-  }, []);
+  }, [hasHydrated, assetInput, setLoanResult, setCurrentStep, router]);
 
   const handleNext = () => {
     router.push("/region");
@@ -75,20 +74,28 @@ export default function ResultPage() {
       <div className="flex flex-col gap-6">
         <AffordabilityCard />
 
-        <PolicyLoanCard />
+        <PolicyCard />
 
-        <PolicyBenefitCard />
+        <LoanExplorer />
 
-        <LoanSlider onLoanAmountChange={handleLoanAmountChange} />
+        <CollapsibleCard
+          title="전세 vs 매매 비교"
+          defaultOpen={false}
+          preview="전세 유지 vs 매매 전환"
+        >
+          <ScenarioComparisonCard
+            assetInput={assetInput}
+            loanResult={loanResult}
+          />
+        </CollapsibleCard>
 
-        <BankComparisonTable loanAmount={loanAmount} />
-
-        <ScenarioComparisonCard
-          assetInput={assetInput}
-          loanResult={loanResult}
-        />
-
-        <UpgradeSimulatorCard />
+        <CollapsibleCard
+          title="갈아타기 시뮬레이터"
+          defaultOpen={false}
+          preview="1주택 갈아타기"
+        >
+          <UpgradeSimulatorCard />
+        </CollapsibleCard>
       </div>
 
       <div className="mt-10">

--- a/src/components/common/CollapsibleCard.tsx
+++ b/src/components/common/CollapsibleCard.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface CollapsibleCardProps {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+  preview?: React.ReactNode;
+}
+
+export default function CollapsibleCard({
+  title,
+  children,
+  defaultOpen = false,
+  className = "",
+  preview,
+}: CollapsibleCardProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState<number>(0);
+
+  useEffect(() => {
+    if (!contentRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContentHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(contentRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <div className={`rounded-[16px] bg-surface p-6 ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        className="flex w-full items-center justify-between text-left"
+      >
+        <h3 className="text-lg font-semibold text-primary">{title}</h3>
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+          className={`shrink-0 text-secondary transition-transform duration-300 ease-in-out ${
+            isOpen ? "rotate-180" : "rotate-0"
+          }`}
+        >
+          <path
+            d="M4 6L8 10L12 6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {!isOpen && preview && (
+        <p className="mt-2 text-sm text-secondary">{preview}</p>
+      )}
+
+      <div
+        className="overflow-hidden transition-[max-height] duration-300 ease-in-out"
+        style={{ maxHeight: isOpen ? `${contentHeight}px` : "0px" }}
+      >
+        <div ref={contentRef}>
+          <div className="pt-4">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { default as Input } from "./Input";
 export { default as Select } from "./Select";
 export { default as Toggle } from "./Toggle";
 export { default as Card } from "./Card";
+export { default as CollapsibleCard } from "./CollapsibleCard";
 export { default as Badge } from "./Badge";
 export { default as Skeleton } from "./Skeleton";
 export { default as Modal } from "./Modal";

--- a/src/components/result/LoanExplorer.tsx
+++ b/src/components/result/LoanExplorer.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { Card, Skeleton, Badge, Button, Select } from "@/components/common";
+import { formatToKoreanWon } from "@/lib/utils/format";
+import { calculateMonthlyPayment } from "@/lib/calculation";
+import { useHousePinStore } from "@/store/useHousePinStore";
+import type { BankLoanProduct } from "@/lib/api/fss";
+
+type RateFilter = "all" | "fixed" | "variable" | "mixed";
+type SortOption =
+  | "minRate-asc"
+  | "minRate-desc"
+  | "monthly-asc"
+  | "bankName-asc";
+
+const RATE_FILTER_LABELS: Record<RateFilter, string> = {
+  all: "전체",
+  fixed: "고정",
+  variable: "변동",
+  mixed: "혼합",
+};
+
+const SORT_LABELS: Record<SortOption, string> = {
+  "minRate-asc": "최저금리 낮은순",
+  "minRate-desc": "최저금리 높은순",
+  "monthly-asc": "월상환액 낮은순",
+  "bankName-asc": "은행명 가나다순",
+};
+
+const PAGE_SIZE = 10;
+
+export default function LoanExplorer() {
+  const loanResult = useHousePinStore((s) => s.loanResult);
+  const assetInput = useHousePinStore((s) => s.assetInput);
+
+  const maxLoan = loanResult?.finalLoanLimit ?? 0;
+  const [loanAmount, setLoanAmount] = useState(maxLoan);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 은행 상품 상태
+  const [products, setProducts] = useState<BankLoanProduct[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [rateFilter, setRateFilter] = useState<RateFilter>("all");
+  const [sortOption, setSortOption] = useState<SortOption>("minRate-asc");
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  // maxLoan이 바뀌면 슬라이더도 리셋
+  useEffect(() => {
+    setLoanAmount(maxLoan);
+  }, [maxLoan]);
+
+  const handleSliderChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = Number(e.target.value);
+      const snapped = Math.round(raw / 100) * 100;
+      setLoanAmount(snapped);
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => {
+        setLoanAmount(snapped);
+      }, 300);
+    },
+    [],
+  );
+
+  // 디바운스 정리
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // 상품 데이터 페치
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchProducts() {
+      setIsLoading(true);
+      setError(null);
+      setRateFilter("all");
+
+      try {
+        const type =
+          assetInput.transactionType === "jeonse" ? "rent" : "mortgage";
+        const res = await fetch(`/api/loan-products?type=${type}`, {
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          throw new Error("대출 상품 데이터를 불러오지 못했습니다.");
+        }
+
+        const data = await res.json();
+
+        const allProducts: BankLoanProduct[] = [];
+        for (const bank of data.banks ?? []) {
+          for (const product of bank.products ?? []) {
+            allProducts.push(product);
+          }
+        }
+        setProducts(allProducts);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(
+          err instanceof Error
+            ? err.message
+            : "알 수 없는 오류가 발생했습니다.",
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchProducts();
+
+    return () => {
+      controller.abort();
+    };
+  }, [assetInput.transactionType]);
+
+  const handleRetry = useCallback(() => {
+    setError(null);
+    setIsLoading(true);
+    const type =
+      assetInput.transactionType === "jeonse" ? "rent" : "mortgage";
+    fetch(`/api/loan-products?type=${type}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("대출 상품 데이터를 불러오지 못했습니다.");
+        return res.json();
+      })
+      .then((data) => {
+        const allProducts: BankLoanProduct[] = [];
+        for (const bank of data.banks ?? []) {
+          for (const product of bank.products ?? []) {
+            allProducts.push(product);
+          }
+        }
+        setProducts(allProducts);
+      })
+      .catch((err) => {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "알 수 없는 오류가 발생했습니다.",
+        );
+      })
+      .finally(() => setIsLoading(false));
+  }, [assetInput.transactionType]);
+
+  // 필터나 정렬 변경 시 페이지네이션 초기화
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [rateFilter, sortOption]);
+
+  // 필터 + 정렬 + 월상환액 계산
+  const displayProducts = useMemo(() => {
+    const filtered =
+      rateFilter === "all"
+        ? products
+        : products.filter((p) => p.rateType === rateFilter);
+
+    const withCalculations = filtered.map((p) => {
+      const monthly = Math.round(
+        calculateMonthlyPayment(
+          loanAmount,
+          p.minRate,
+          assetInput.loanTermYears,
+        ),
+      );
+
+      return {
+        ...p,
+        calculatedMonthlyPayment: monthly,
+      };
+    });
+
+    return withCalculations.sort((a, b) => {
+      switch (sortOption) {
+        case "minRate-asc":
+          return a.minRate - b.minRate;
+        case "minRate-desc":
+          return b.minRate - a.minRate;
+        case "monthly-asc":
+          return a.calculatedMonthlyPayment - b.calculatedMonthlyPayment;
+        case "bankName-asc":
+          return a.bankName.localeCompare(b.bankName, "ko");
+        default:
+          return 0;
+      }
+    });
+  }, [products, rateFilter, sortOption, loanAmount, assetInput.loanTermYears]);
+
+  const paginatedProducts = useMemo(
+    () => displayProducts.slice(0, visibleCount),
+    [displayProducts, visibleCount],
+  );
+
+  const totalCount = displayProducts.length;
+  const shownCount = Math.min(visibleCount, totalCount);
+  const hasMore = shownCount < totalCount;
+
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => prev + PAGE_SIZE);
+  };
+
+  const rateTypeBadgeVariant = (type: BankLoanProduct["rateType"]) => {
+    if (type === "fixed") return "info" as const;
+    if (type === "variable") return "warning" as const;
+    return "success" as const;
+  };
+
+  if (!loanResult || maxLoan <= 0) return null;
+
+  const monthlyPayment = Math.round(
+    calculateMonthlyPayment(loanAmount, 4.0, assetInput.loanTermYears),
+  );
+
+  const progress = maxLoan > 0 ? (loanAmount / maxLoan) * 100 : 0;
+
+  return (
+    <Card>
+      <h3 className="mb-1 text-lg font-semibold text-primary">
+        대출 조건 탐색
+      </h3>
+      <p className="mb-6 text-sm text-secondary">
+        대출 금액을 조절하고 은행별 금리를 비교해보세요
+      </p>
+
+      {/* ── 슬라이더 섹션 ── */}
+      <div className="mb-4 text-center">
+        <p className="text-[28px] font-bold text-accent">
+          {formatToKoreanWon(loanAmount)}
+        </p>
+      </div>
+
+      <div className="relative mb-6 px-1">
+        <input
+          type="range"
+          min={0}
+          max={maxLoan}
+          step={100}
+          value={loanAmount}
+          onChange={handleSliderChange}
+          aria-label="대출 금액 조절 슬라이더"
+          aria-valuemin={0}
+          aria-valuemax={maxLoan}
+          aria-valuenow={loanAmount}
+          aria-valuetext={formatToKoreanWon(loanAmount)}
+          className="slider-input w-full"
+          style={
+            {
+              "--progress": `${progress}%`,
+            } as React.CSSProperties
+          }
+        />
+        <div className="mt-2 flex justify-between text-xs text-secondary">
+          <span>0원</span>
+          <span>{formatToKoreanWon(maxLoan)}</span>
+        </div>
+      </div>
+
+      <div className="mb-6 rounded-[12px] bg-surface p-4 text-center">
+        <p className="mb-1 text-sm text-secondary">예상 월 상환액</p>
+        <p className="text-xl font-bold text-primary">
+          {formatToKoreanWon(monthlyPayment)}
+        </p>
+      </div>
+
+      {/* ── 구분선 ── */}
+      <hr className="mb-6 border-border" />
+
+      {/* ── 은행 비교 섹션 ── */}
+      {isLoading ? (
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} height="80px" />
+          ))}
+        </div>
+      ) : error ? (
+        <>
+          <p className="mb-3 text-sm text-danger">{error}</p>
+          <Button variant="secondary" size="sm" onClick={handleRetry}>
+            다시 시도
+          </Button>
+        </>
+      ) : loanAmount <= 0 ? (
+        <p className="py-8 text-center text-sm text-secondary">
+          대출 금액을 설정하면 은행별 금리를 비교할 수 있어요.
+        </p>
+      ) : (
+        <>
+          <h4 className="text-base font-semibold text-primary">
+            은행별 금리 비교
+          </h4>
+          <p className="mt-1 mb-4 text-sm text-secondary">
+            {formatToKoreanWon(loanAmount)} 대출 기준 비교
+          </p>
+
+          {/* 필터 탭 + 정렬 */}
+          <div className="mb-5 flex flex-col gap-3">
+            <div
+              className="flex gap-2"
+              role="tablist"
+              aria-label="금리 유형 필터"
+            >
+              {(Object.keys(RATE_FILTER_LABELS) as RateFilter[]).map((key) => (
+                <button
+                  key={key}
+                  role="tab"
+                  aria-selected={rateFilter === key}
+                  onClick={() => setRateFilter(key)}
+                  className={`
+                    rounded-full px-4 py-2 text-sm font-semibold transition-colors duration-200
+                    ${
+                      rateFilter === key
+                        ? "bg-accent text-white"
+                        : "bg-surface text-secondary hover:text-primary"
+                    }
+                  `.trim()}
+                >
+                  {RATE_FILTER_LABELS[key]}
+                </button>
+              ))}
+            </div>
+
+            <div className="w-[160px] self-end">
+              <Select
+                size="sm"
+                options={(Object.keys(SORT_LABELS) as SortOption[]).map(
+                  (key) => ({
+                    value: key,
+                    label: SORT_LABELS[key],
+                  }),
+                )}
+                value={sortOption}
+                onValueChange={(v) => setSortOption(v as SortOption)}
+              />
+            </div>
+          </div>
+
+          {displayProducts.length === 0 ? (
+            <p className="py-8 text-center text-sm text-secondary">
+              해당 조건에 맞는 상품이 없습니다.
+            </p>
+          ) : (
+            <>
+              {/* 데스크톱 테이블 */}
+              <div className="hidden sm:block">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-secondary">
+                      <th className="pb-3 font-medium">은행명</th>
+                      <th className="pb-3 font-medium">상품명</th>
+                      <th className="pb-3 font-medium">금리유형</th>
+                      <th className="pb-3 text-right font-medium">최저금리</th>
+                      <th className="pb-3 text-right font-medium">대출한도</th>
+                      <th className="pb-3 text-right font-medium">월상환액</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paginatedProducts.map((p, idx) => (
+                      <tr
+                        key={`${p.bankName}-${p.productName}-${p.rateType}-${idx}`}
+                        className="border-b border-border last:border-b-0"
+                      >
+                        <td className="py-4 font-semibold text-primary">
+                          {p.bankName}
+                        </td>
+                        <td className="py-4 text-primary">{p.productName}</td>
+                        <td className="py-4">
+                          <Badge variant={rateTypeBadgeVariant(p.rateType)}>
+                            {p.rateTypeName}
+                          </Badge>
+                        </td>
+                        <td className="py-4 text-right font-semibold text-accent">
+                          {p.minRate.toFixed(2)}%
+                        </td>
+                        <td className="py-4 text-right text-primary">
+                          {p.loanLimit || "-"}
+                        </td>
+                        <td className="py-4 text-right font-semibold text-primary">
+                          {formatToKoreanWon(p.calculatedMonthlyPayment)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* 모바일 카드 리스트 */}
+              <div className="flex flex-col gap-3 sm:hidden">
+                {paginatedProducts.map((p, idx) => (
+                  <div
+                    key={`mobile-${p.bankName}-${p.productName}-${p.rateType}-${idx}`}
+                    className="rounded-[12px] border border-border p-4"
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="font-semibold text-primary">
+                        {p.bankName}
+                      </span>
+                      <Badge variant={rateTypeBadgeVariant(p.rateType)}>
+                        {p.rateTypeName}
+                      </Badge>
+                    </div>
+                    <p className="mb-3 text-sm text-secondary">
+                      {p.productName}
+                    </p>
+
+                    <div className="flex flex-col gap-1 text-sm">
+                      <div className="flex justify-between">
+                        <span className="text-secondary">최저금리</span>
+                        <span className="font-semibold text-accent">
+                          {p.minRate.toFixed(2)}%
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-secondary">대출한도</span>
+                        <span className="text-primary">
+                          {p.loanLimit || "-"}
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-secondary">월상환액</span>
+                        <span className="font-semibold text-primary">
+                          {formatToKoreanWon(p.calculatedMonthlyPayment)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 더보기 영역 */}
+              <div className="mt-5 flex flex-col items-center gap-2">
+                <p className="text-sm text-secondary">
+                  {shownCount} / {totalCount}개 상품
+                </p>
+                {hasMore && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleLoadMore}
+                  >
+                    더보기
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/components/result/PolicyBenefitContent.tsx
+++ b/src/components/result/PolicyBenefitContent.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useHousePinStore } from "@/store/useHousePinStore";
+import { Badge } from "@/components/common";
+import { checkAllPolicyBenefits } from "@/lib/calculation/policyBenefit";
+import { formatToKoreanWon } from "@/lib/utils/format";
+import type { PolicyBenefit, PolicyBenefitInput } from "@/types/policyBenefit";
+
+export default function PolicyBenefitContent() {
+  const assetInput = useHousePinStore((s) => s.assetInput);
+  const loanResult = useHousePinStore((s) => s.loanResult);
+  const [showIneligible, setShowIneligible] = useState(false);
+
+  const benefitResult = useMemo(() => {
+    if (!loanResult) return null;
+
+    const input: PolicyBenefitInput = {
+      annualIncome: assetInput.annualIncome,
+      numberOfHomes: assetInput.numberOfHomes,
+      isFirstTimeBuyer: assetInput.isFirstTimeBuyer,
+      isNewlywed: assetInput.isNewlywed,
+      hasChildren: false,
+      age: 30,
+      purchasePrice: loanResult.affordablePrice,
+      transactionType: assetInput.transactionType,
+    };
+
+    return checkAllPolicyBenefits(input);
+  }, [assetInput, loanResult]);
+
+  if (!benefitResult) return null;
+
+  const { eligible, ineligible, totalMonthlySavings, bestLoan } = benefitResult;
+
+  return (
+    <>
+      {/* 요약 */}
+      <div className="mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-secondary">받을 수 있는 혜택</span>
+          {eligible.length > 0 && (
+            <Badge variant="success">{eligible.length}개</Badge>
+          )}
+        </div>
+        {totalMonthlySavings > 0 && (
+          <p className="mt-1 text-sm text-secondary">
+            최대{" "}
+            <span className="font-semibold text-success">
+              월 {formatToKoreanWon(Math.round(totalMonthlySavings))}
+            </span>{" "}
+            절약 가능
+          </p>
+        )}
+      </div>
+
+      {/* 자격 충족 혜택 목록 */}
+      {eligible.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          {eligible.map((benefit) => (
+            <BenefitItem
+              key={benefit.name}
+              benefit={benefit}
+              isBest={bestLoan?.name === benefit.name}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="py-4 text-center text-sm text-secondary">
+          현재 조건으로 해당하는 정책 혜택이 없어요
+        </p>
+      )}
+
+      {/* 미자격 혜택 접기/펼치기 */}
+      {ineligible.length > 0 && (
+        <div className="mt-5">
+          <button
+            type="button"
+            className="w-full text-center text-sm text-secondary hover:text-primary transition-colors"
+            onClick={() => setShowIneligible(!showIneligible)}
+          >
+            {showIneligible
+              ? "미자격 혜택 접기"
+              : `미자격 혜택 ${ineligible.length}개 보기`}
+          </button>
+
+          {showIneligible && (
+            <div className="mt-3 flex flex-col gap-2">
+              {ineligible.map((benefit) => (
+                <div
+                  key={benefit.name}
+                  className="rounded-[12px] border border-border bg-white p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-secondary">
+                      {benefit.name}
+                    </span>
+                    <Badge variant="danger">미자격</Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-secondary">{benefit.reason}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+// ──────────────────────────────────────────────
+// 개별 혜택 아이템
+// ──────────────────────────────────────────────
+
+interface BenefitItemProps {
+  benefit: PolicyBenefit;
+  isBest: boolean;
+}
+
+function BenefitItem({ benefit, isBest }: BenefitItemProps) {
+  const isLoan = benefit.category === "loan";
+
+  return (
+    <div
+      className={`rounded-[12px] border p-4 ${
+        isBest ? "border-accent bg-accent-light" : "border-border"
+      }`}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-base font-semibold text-primary">
+          {benefit.name}
+        </span>
+        {isBest && <Badge variant="info">최적</Badge>}
+        {benefit.category === "tax" && <Badge variant="warning">세금 감면</Badge>}
+      </div>
+
+      <p className="mb-3 text-xs text-secondary">{benefit.reason}</p>
+
+      {isLoan && benefit.maxLoanAmount > 0 && (
+        <div className="flex flex-col gap-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-secondary">금리</span>
+            <span className="font-semibold text-primary">
+              {benefit.interestRate.min}% ~ {benefit.interestRate.max}%
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-secondary">최대 한도</span>
+            <span className="font-semibold text-primary">
+              {formatToKoreanWon(benefit.maxLoanAmount)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {(benefit.monthlySavings ?? 0) > 0 && (
+        <p className="mt-3 text-xs text-success">
+          {isLoan
+            ? `시중 금리 대비 월 약 ${formatToKoreanWon(Math.round(benefit.monthlySavings!))} 절약`
+            : `최대 ${formatToKoreanWon(benefit.monthlySavings!)} 감면`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/result/PolicyCard.tsx
+++ b/src/components/result/PolicyCard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/common";
+import PolicyLoanContent from "./PolicyLoanContent";
+import PolicyBenefitContent from "./PolicyBenefitContent";
+
+type TabKey = "loan" | "benefit";
+
+interface Tab {
+  key: TabKey;
+  label: string;
+}
+
+const TABS: Tab[] = [
+  { key: "loan", label: "정책 대출" },
+  { key: "benefit", label: "정책 혜택" },
+];
+
+export default function PolicyCard() {
+  const [activeTab, setActiveTab] = useState<TabKey>("loan");
+
+  return (
+    <Card>
+      <h3 className="mb-3 text-lg font-semibold text-primary">정책 지원</h3>
+
+      {/* 탭 바 */}
+      <div className="mb-4 flex gap-2">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              activeTab === tab.key
+                ? "bg-accent text-white"
+                : "bg-surface text-secondary hover:text-primary"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 탭 콘텐츠 */}
+      {activeTab === "loan" ? <PolicyLoanContent /> : <PolicyBenefitContent />}
+    </Card>
+  );
+}

--- a/src/components/result/PolicyLoanContent.tsx
+++ b/src/components/result/PolicyLoanContent.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useHousePinStore } from "@/store/useHousePinStore";
+import { Badge } from "@/components/common";
+import { POLICY_LOANS } from "@/constants/policy";
+import { formatToKoreanWon } from "@/lib/utils/format";
+
+interface PolicyLoanInfo {
+  key: "didimdol" | "bogeumjari" | "batimok";
+  name: string;
+  rates: { min: number; max: number };
+  maxLoan: number;
+}
+
+const POLICY_LOAN_LIST: PolicyLoanInfo[] = [
+  {
+    key: "didimdol",
+    name: POLICY_LOANS.didimdol.name,
+    rates: POLICY_LOANS.didimdol.rates,
+    maxLoan: POLICY_LOANS.didimdol.maxLoan,
+  },
+  {
+    key: "bogeumjari",
+    name: POLICY_LOANS.bogeumjari.name,
+    rates: POLICY_LOANS.bogeumjari.rates,
+    maxLoan: POLICY_LOANS.bogeumjari.maxLoan,
+  },
+  {
+    key: "batimok",
+    name: POLICY_LOANS.batimok.name,
+    rates: POLICY_LOANS.batimok.rates,
+    maxLoan: POLICY_LOANS.batimok.maxLoanSeoul,
+  },
+];
+
+/** 시중 평균 금리 기준 (은행 금리 대비 정책대출 금리 차이 산출용) */
+const MARKET_AVG_RATE = 4.2;
+
+export default function PolicyLoanContent() {
+  const loanResult = useHousePinStore((s) => s.loanResult);
+
+  if (!loanResult) return null;
+
+  const eligibleLoans = POLICY_LOAN_LIST.filter(
+    (loan) => loanResult.policyLoans[loan.key],
+  );
+
+  if (eligibleLoans.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-secondary">
+        현재 조건으로 해당하는 정책 대출이 없어요
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <p className="mb-4 text-sm text-secondary">
+        자격 조건에 해당하는 정책대출이 있어요
+      </p>
+
+      <div className="flex flex-col gap-4">
+        {eligibleLoans.map((loan) => {
+          const rateDiff = MARKET_AVG_RATE - loan.rates.min;
+          const rateDiffText =
+            rateDiff > 0
+              ? `시중 금리 대비 약 ${rateDiff.toFixed(1)}%p 낮음`
+              : null;
+
+          return (
+            <div
+              key={loan.key}
+              className="rounded-[12px] border border-border p-4"
+            >
+              <div className="mb-3 flex items-center gap-2">
+                <span className="text-base font-semibold text-primary">
+                  {loan.name}
+                </span>
+                <Badge variant="success">자격 해당</Badge>
+              </div>
+
+              <div className="flex flex-col gap-1 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-secondary">예상 금리</span>
+                  <span className="font-semibold text-primary">
+                    {loan.rates.min}% ~ {loan.rates.max}%
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-secondary">최대 한도</span>
+                  <span className="font-semibold text-primary">
+                    {formatToKoreanWon(loan.maxLoan)}
+                  </span>
+                </div>
+              </div>
+
+              {rateDiffText && (
+                <p className="mt-3 text-xs text-success">{rateDiffText}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/result/ScenarioComparisonCard.tsx
+++ b/src/components/result/ScenarioComparisonCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Card } from "@/components/common";
 import { formatToKoreanWon } from "@/lib/utils/format";
 import { compareJeonseVsBuy } from "@/lib/calculation/scenarioComparison";
 import { DEFAULT_SCENARIO } from "@/constants/scenario";
@@ -69,191 +68,189 @@ export default function ScenarioComparisonCard({
   );
 
   return (
-    <Card title="전세 vs 매매 비교">
-      <div className="flex flex-col gap-5">
-        {/* 결론 히어로 */}
-        <div
-          className={`rounded-[12px] px-4 py-5 text-center ${
-            isBuyBetter ? "bg-accent-light" : "bg-success-light"
+    <div className="flex flex-col gap-5">
+      {/* 결론 히어로 */}
+      <div
+        className={`rounded-[12px] px-4 py-5 text-center ${
+          isBuyBetter ? "bg-accent-light" : "bg-success-light"
+        }`}
+      >
+        <p
+          className={`text-xs font-medium ${
+            isBuyBetter ? "text-accent" : "text-success"
           }`}
         >
-          <p
-            className={`text-xs font-medium ${
-              isBuyBetter ? "text-accent" : "text-success"
-            }`}
-          >
-            {comparisonYears}년 기준 분석 결과
-          </p>
-          <p
-            className={`mt-1 text-lg font-bold ${
-              isBuyBetter ? "text-accent" : "text-success"
-            }`}
-          >
-            {isBuyBetter ? "매매가 유리합니다" : "전세 유지가 유리합니다"}
-          </p>
-          <p className="mt-2 text-sm text-secondary">
-            {isBuyBetter ? "매매" : "전세"} 시{" "}
-            <span className="font-semibold text-primary">
-              {formatToKoreanWon(result.comparison.savingsAmount)}
-            </span>{" "}
-            절약
-          </p>
-        </div>
-
-        {/* 조건 조절 */}
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-secondary">비교 기간</span>
-            <div className="flex gap-1.5">
-              {YEAR_OPTIONS.map((y) => (
-                <button
-                  key={y}
-                  onClick={() => setComparisonYears(y)}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                    comparisonYears === y
-                      ? "bg-accent text-white"
-                      : "bg-surface text-secondary hover:text-primary"
-                  }`}
-                >
-                  {y}년
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-secondary">
-              시세 상승률 연 {priceGrowthRate}%
-            </span>
-            <input
-              type="range"
-              min={0}
-              max={10}
-              step={0.5}
-              value={priceGrowthRate}
-              onChange={(e) => setPriceGrowthRate(Number(e.target.value))}
-              className="h-1.5 w-28 cursor-pointer accent-accent"
-            />
-          </div>
-        </div>
-
-        <div className="border-t border-border" />
-
-        {/* 비교 테이블 */}
-        <div className="grid grid-cols-3 gap-2 text-center text-sm">
-          <div />
-          <div className="font-semibold text-success">전세 유지</div>
-          <div className="font-semibold text-accent">매매 전환</div>
-
-          <div className="text-left text-secondary">총 비용</div>
-          <div className="font-medium text-primary">
-            {formatToKoreanWon(result.jeonse.totalCost)}
-          </div>
-          <div className="font-medium text-primary">
-            {formatToKoreanWon(result.buy.totalCost)}
-          </div>
-
-          <div className="text-left text-secondary">자산 형성</div>
-          <div className="text-secondary">0원</div>
-          <div className="font-medium text-accent">
-            +{formatToKoreanWon(result.buy.assetFormed)}
-          </div>
-
-          <div className="text-left text-secondary">순비용</div>
-          <div className="font-bold text-primary">
-            {formatToKoreanWon(result.jeonse.netCost)}
-          </div>
-          <div className="font-bold text-primary">
-            {formatToKoreanWon(Math.abs(result.buy.netCost))}
-            {result.buy.netCost < 0 && (
-              <span className="ml-1 text-xs text-success">이득</span>
-            )}
-          </div>
-        </div>
-
-        <div className="border-t border-border" />
-
-        {/* 연도별 추이 바 차트 */}
-        <div className="flex flex-col gap-2">
-          <p className="text-sm font-semibold text-primary">연도별 순비용 추이</p>
-          <div className="flex flex-col gap-1.5">
-            {result.yearlyBreakdown.map((row) => (
-              <div key={row.year} className="flex items-center gap-2">
-                <span className="w-6 text-right text-xs text-secondary">
-                  {row.year}년
-                </span>
-                <div className="flex flex-1 flex-col gap-0.5">
-                  <div className="flex h-2.5 items-center rounded-full bg-surface">
-                    <div
-                      className="h-full rounded-full bg-success/60"
-                      style={{
-                        width: `${(Math.abs(row.jeonseCumulative) / maxCumulative) * 100}%`,
-                      }}
-                    />
-                  </div>
-                  <div className="flex h-2.5 items-center rounded-full bg-surface">
-                    <div
-                      className={`h-full rounded-full ${
-                        row.buyCumulative < 0
-                          ? "bg-accent/60"
-                          : "bg-accent/40"
-                      }`}
-                      style={{
-                        width: `${(Math.abs(row.buyCumulative) / maxCumulative) * 100}%`,
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="flex gap-4 text-[11px] text-secondary">
-            <div className="flex items-center gap-1">
-              <span className="inline-block h-2 w-2 rounded-full bg-success/60" />
-              전세
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="inline-block h-2 w-2 rounded-full bg-accent/60" />
-              매매
-            </div>
-          </div>
-        </div>
-
-        {/* 손익분기점 */}
-        {result.comparison.breakEvenYears !== null && (
-          <>
-            <div className="border-t border-border" />
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-secondary">손익분기점</span>
-              <span className="text-sm font-semibold text-primary">
-                {result.comparison.breakEvenYears}년 후
-              </span>
-            </div>
-          </>
-        )}
-
-        {/* 월 부담 차이 */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-secondary">매매 시 추가 월 부담</span>
-          <span
-            className={`text-sm font-semibold ${
-              result.comparison.monthlyCostDiff > 0
-                ? "text-danger"
-                : "text-success"
-            }`}
-          >
-            {result.comparison.monthlyCostDiff > 0 ? "+" : ""}
-            {formatToKoreanWon(result.comparison.monthlyCostDiff)}/월
-          </span>
-        </div>
-
-        {/* 전제 조건 */}
-        <p className="text-[11px] leading-relaxed text-secondary">
-          * 전세금 {formatToKoreanWon(estimatedJeonse)} (매매가 70%) 기준 ·
-          예금금리 {DEFAULT_SCENARIO.depositRate}% · 전세 상승률{" "}
-          {DEFAULT_SCENARIO.jeonseRenewalRate}%/년 · 대출금리{" "}
-          {DEFAULT_SCENARIO.mortgageRate}% · 시세 상승률 {priceGrowthRate}%/년
+          {comparisonYears}년 기준 분석 결과
+        </p>
+        <p
+          className={`mt-1 text-lg font-bold ${
+            isBuyBetter ? "text-accent" : "text-success"
+          }`}
+        >
+          {isBuyBetter ? "매매가 유리합니다" : "전세 유지가 유리합니다"}
+        </p>
+        <p className="mt-2 text-sm text-secondary">
+          {isBuyBetter ? "매매" : "전세"} 시{" "}
+          <span className="font-semibold text-primary">
+            {formatToKoreanWon(result.comparison.savingsAmount)}
+          </span>{" "}
+          절약
         </p>
       </div>
-    </Card>
+
+      {/* 조건 조절 */}
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-secondary">비교 기간</span>
+          <div className="flex gap-1.5">
+            {YEAR_OPTIONS.map((y) => (
+              <button
+                key={y}
+                onClick={() => setComparisonYears(y)}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  comparisonYears === y
+                    ? "bg-accent text-white"
+                    : "bg-surface text-secondary hover:text-primary"
+                }`}
+              >
+                {y}년
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-secondary">
+            시세 상승률 연 {priceGrowthRate}%
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={10}
+            step={0.5}
+            value={priceGrowthRate}
+            onChange={(e) => setPriceGrowthRate(Number(e.target.value))}
+            className="h-1.5 w-28 cursor-pointer accent-accent"
+          />
+        </div>
+      </div>
+
+      <div className="border-t border-border" />
+
+      {/* 비교 테이블 */}
+      <div className="grid grid-cols-3 gap-2 text-center text-sm">
+        <div />
+        <div className="font-semibold text-success">전세 유지</div>
+        <div className="font-semibold text-accent">매매 전환</div>
+
+        <div className="text-left text-secondary">총 비용</div>
+        <div className="font-medium text-primary">
+          {formatToKoreanWon(result.jeonse.totalCost)}
+        </div>
+        <div className="font-medium text-primary">
+          {formatToKoreanWon(result.buy.totalCost)}
+        </div>
+
+        <div className="text-left text-secondary">자산 형성</div>
+        <div className="text-secondary">0원</div>
+        <div className="font-medium text-accent">
+          +{formatToKoreanWon(result.buy.assetFormed)}
+        </div>
+
+        <div className="text-left text-secondary">순비용</div>
+        <div className="font-bold text-primary">
+          {formatToKoreanWon(result.jeonse.netCost)}
+        </div>
+        <div className="font-bold text-primary">
+          {formatToKoreanWon(Math.abs(result.buy.netCost))}
+          {result.buy.netCost < 0 && (
+            <span className="ml-1 text-xs text-success">이득</span>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-border" />
+
+      {/* 연도별 추이 바 차트 */}
+      <div className="flex flex-col gap-2">
+        <p className="text-sm font-semibold text-primary">연도별 순비용 추이</p>
+        <div className="flex flex-col gap-1.5">
+          {result.yearlyBreakdown.map((row) => (
+            <div key={row.year} className="flex items-center gap-2">
+              <span className="w-6 text-right text-xs text-secondary">
+                {row.year}년
+              </span>
+              <div className="flex flex-1 flex-col gap-0.5">
+                <div className="flex h-2.5 items-center rounded-full bg-surface">
+                  <div
+                    className="h-full rounded-full bg-success/60"
+                    style={{
+                      width: `${(Math.abs(row.jeonseCumulative) / maxCumulative) * 100}%`,
+                    }}
+                  />
+                </div>
+                <div className="flex h-2.5 items-center rounded-full bg-surface">
+                  <div
+                    className={`h-full rounded-full ${
+                      row.buyCumulative < 0
+                        ? "bg-accent/60"
+                        : "bg-accent/40"
+                    }`}
+                    style={{
+                      width: `${(Math.abs(row.buyCumulative) / maxCumulative) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-4 text-[11px] text-secondary">
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-success/60" />
+            전세
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-accent/60" />
+            매매
+          </div>
+        </div>
+      </div>
+
+      {/* 손익분기점 */}
+      {result.comparison.breakEvenYears !== null && (
+        <>
+          <div className="border-t border-border" />
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-secondary">손익분기점</span>
+            <span className="text-sm font-semibold text-primary">
+              {result.comparison.breakEvenYears}년 후
+            </span>
+          </div>
+        </>
+      )}
+
+      {/* 월 부담 차이 */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-secondary">매매 시 추가 월 부담</span>
+        <span
+          className={`text-sm font-semibold ${
+            result.comparison.monthlyCostDiff > 0
+              ? "text-danger"
+              : "text-success"
+          }`}
+        >
+          {result.comparison.monthlyCostDiff > 0 ? "+" : ""}
+          {formatToKoreanWon(result.comparison.monthlyCostDiff)}/월
+        </span>
+      </div>
+
+      {/* 전제 조건 */}
+      <p className="text-[11px] leading-relaxed text-secondary">
+        * 전세금 {formatToKoreanWon(estimatedJeonse)} (매매가 70%) 기준 ·
+        예금금리 {DEFAULT_SCENARIO.depositRate}% · 전세 상승률{" "}
+        {DEFAULT_SCENARIO.jeonseRenewalRate}%/년 · 대출금리{" "}
+        {DEFAULT_SCENARIO.mortgageRate}% · 시세 상승률 {priceGrowthRate}%/년
+      </p>
+    </div>
   );
 }

--- a/src/components/result/UpgradeSimulatorCard.tsx
+++ b/src/components/result/UpgradeSimulatorCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import { Card, Input, Toggle, Button, Badge } from "@/components/common";
+import { Input, Toggle, Button, Badge } from "@/components/common";
 import { formatToKoreanWon } from "@/lib/utils/format";
 import { simulateUpgrade } from "@/lib/calculation/upgradeSimulator";
 import type { UpgradeInput } from "@/types/upgrade";
@@ -62,304 +62,302 @@ export default function UpgradeSimulatorCard() {
   }, [isInputValid]);
 
   return (
-    <Card title="갈아타기 시뮬레이터">
-      <div className="flex flex-col gap-5">
-        <p className="text-sm text-secondary">
-          현재 집을 팔고 새 집을 살 때, 실수령액과 구매력을 계산해드려요
-        </p>
+    <div className="flex flex-col gap-5">
+      <p className="text-sm text-secondary">
+        현재 집을 팔고 새 집을 살 때, 실수령액과 구매력을 계산해드려요
+      </p>
 
-        {/* 현재 주택 정보 */}
-        <div className="flex flex-col gap-3">
-          <p className="text-sm font-semibold text-primary">현재 보유 주택</p>
+      {/* 현재 주택 정보 */}
+      <div className="flex flex-col gap-3">
+        <p className="text-sm font-semibold text-primary">현재 보유 주택</p>
 
-          <Input
-            label="현재 집 예상 매도가"
-            type="number"
-            suffix="만원"
-            placeholder="80,000"
-            value={String(input.currentHomePrice || "")}
-            onValueChange={handleNumberChange("currentHomePrice")}
+        <Input
+          label="현재 집 예상 매도가"
+          type="number"
+          suffix="만원"
+          placeholder="80,000"
+          value={String(input.currentHomePrice || "")}
+          onValueChange={handleNumberChange("currentHomePrice")}
+        />
+
+        <Input
+          label="매입 당시 가격"
+          type="number"
+          suffix="만원"
+          placeholder="60,000"
+          value={String(input.purchasedPrice || "")}
+          onValueChange={handleNumberChange("purchasedPrice")}
+        />
+
+        <Input
+          label="현재 대출 잔액"
+          type="number"
+          suffix="만원"
+          placeholder="20,000"
+          value={String(input.currentLoanBalance || "")}
+          onValueChange={handleNumberChange("currentLoanBalance")}
+        />
+
+        <Input
+          label="보유 기간"
+          type="number"
+          suffix="년"
+          placeholder="5"
+          value={String(input.holdingPeriodYears || "")}
+          onValueChange={handleNumberChange("holdingPeriodYears")}
+        />
+
+        <div className="flex items-center justify-between">
+          <Toggle
+            label="실거주 2년 이상"
+            checked={input.isActualResidence}
+            onChange={(checked) => updateField("isActualResidence", checked)}
           />
-
-          <Input
-            label="매입 당시 가격"
-            type="number"
-            suffix="만원"
-            placeholder="60,000"
-            value={String(input.purchasedPrice || "")}
-            onValueChange={handleNumberChange("purchasedPrice")}
-          />
-
-          <Input
-            label="현재 대출 잔액"
-            type="number"
-            suffix="만원"
-            placeholder="20,000"
-            value={String(input.currentLoanBalance || "")}
-            onValueChange={handleNumberChange("currentLoanBalance")}
-          />
-
-          <Input
-            label="보유 기간"
-            type="number"
-            suffix="년"
-            placeholder="5"
-            value={String(input.holdingPeriodYears || "")}
-            onValueChange={handleNumberChange("holdingPeriodYears")}
-          />
-
-          <div className="flex items-center justify-between">
-            <Toggle
-              label="실거주 2년 이상"
-              checked={input.isActualResidence}
-              onChange={(checked) => updateField("isActualResidence", checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between">
-            <Toggle
-              label="조정대상지역"
-              checked={input.isRegulatedArea}
-              onChange={(checked) => updateField("isRegulatedArea", checked)}
-            />
-          </div>
         </div>
 
-        <div className="border-t border-border" />
-
-        {/* 새 주택 조건 */}
-        <div className="flex flex-col gap-3">
-          <p className="text-sm font-semibold text-primary">새 주택 조건</p>
-
-          <Input
-            label="연소득"
-            type="number"
-            suffix="만원"
-            placeholder="8,000"
-            value={String(input.annualIncome || "")}
-            onValueChange={handleNumberChange("annualIncome")}
+        <div className="flex items-center justify-between">
+          <Toggle
+            label="조정대상지역"
+            checked={input.isRegulatedArea}
+            onChange={(checked) => updateField("isRegulatedArea", checked)}
           />
+        </div>
+      </div>
 
-          <Input
-            label="추가 투입 가능 현금"
-            type="number"
-            suffix="만원"
-            placeholder="5,000"
-            value={String(input.additionalCash || "")}
-            onValueChange={handleNumberChange("additionalCash")}
-          />
+      <div className="border-t border-border" />
 
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-primary">대출 기간</span>
-            <div className="flex gap-1.5">
-              {LOAN_TERM_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => updateField("loanTermYears", opt.value)}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                    input.loanTermYears === opt.value
-                      ? "bg-accent text-white"
-                      : "bg-surface text-secondary hover:text-primary"
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-          </div>
+      {/* 새 주택 조건 */}
+      <div className="flex flex-col gap-3">
+        <p className="text-sm font-semibold text-primary">새 주택 조건</p>
 
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-primary">상환 방식</span>
-            <div className="flex gap-1.5">
+        <Input
+          label="연소득"
+          type="number"
+          suffix="만원"
+          placeholder="8,000"
+          value={String(input.annualIncome || "")}
+          onValueChange={handleNumberChange("annualIncome")}
+        />
+
+        <Input
+          label="추가 투입 가능 현금"
+          type="number"
+          suffix="만원"
+          placeholder="5,000"
+          value={String(input.additionalCash || "")}
+          onValueChange={handleNumberChange("additionalCash")}
+        />
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-primary">대출 기간</span>
+          <div className="flex gap-1.5">
+            {LOAN_TERM_OPTIONS.map((opt) => (
               <button
+                key={opt.value}
                 type="button"
-                onClick={() => updateField("repaymentType", "equal_payment")}
+                onClick={() => updateField("loanTermYears", opt.value)}
                 className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                  input.repaymentType === "equal_payment"
+                  input.loanTermYears === opt.value
                     ? "bg-accent text-white"
                     : "bg-surface text-secondary hover:text-primary"
                 }`}
               >
-                원리금균등
+                {opt.label}
               </button>
-              <button
-                type="button"
-                onClick={() => updateField("repaymentType", "equal_principal")}
-                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                  input.repaymentType === "equal_principal"
-                    ? "bg-accent text-white"
-                    : "bg-surface text-secondary hover:text-primary"
-                }`}
-              >
-                원금균등
-              </button>
-            </div>
+            ))}
           </div>
         </div>
 
-        {/* 계산 버튼 */}
-        <Button
-          fullWidth
-          size="lg"
-          onClick={handleCalculate}
-          disabled={!isInputValid}
-        >
-          갈아타기 계산하기
-        </Button>
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-primary">상환 방식</span>
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={() => updateField("repaymentType", "equal_payment")}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                input.repaymentType === "equal_payment"
+                  ? "bg-accent text-white"
+                  : "bg-surface text-secondary hover:text-primary"
+              }`}
+            >
+              원리금균등
+            </button>
+            <button
+              type="button"
+              onClick={() => updateField("repaymentType", "equal_principal")}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                input.repaymentType === "equal_principal"
+                  ? "bg-accent text-white"
+                  : "bg-surface text-secondary hover:text-primary"
+              }`}
+            >
+              원금균등
+            </button>
+          </div>
+        </div>
+      </div>
 
-        {/* 결과 */}
-        {result && (
-          <>
-            <div className="border-t border-border" />
+      {/* 계산 버튼 */}
+      <Button
+        fullWidth
+        size="lg"
+        onClick={handleCalculate}
+        disabled={!isInputValid}
+      >
+        갈아타기 계산하기
+      </Button>
 
-            {/* 매도 정산 */}
-            <div className="flex flex-col gap-3">
-              <p className="text-sm font-semibold text-primary">매도 정산</p>
+      {/* 결과 */}
+      {result && (
+        <>
+          <div className="border-t border-border" />
 
-              <div className="rounded-[12px] bg-surface p-4">
-                <div className="flex flex-col gap-2">
-                  <ResultRow label="매도가" value={result.saleProceeds.salePrice} />
+          {/* 매도 정산 */}
+          <div className="flex flex-col gap-3">
+            <p className="text-sm font-semibold text-primary">매도 정산</p>
+
+            <div className="rounded-[12px] bg-surface p-4">
+              <div className="flex flex-col gap-2">
+                <ResultRow label="매도가" value={result.saleProceeds.salePrice} />
+                <ResultRow
+                  label="중개수수료"
+                  value={-result.saleProceeds.brokerageFee}
+                  negative
+                />
+                <ResultRow
+                  label="양도소득세"
+                  value={-result.saleProceeds.capitalGainsTax}
+                  negative
+                />
+                <ResultRow
+                  label="대출 상환"
+                  value={-result.saleProceeds.loanRepayment}
+                  negative
+                />
+                <div className="border-t border-border pt-2">
                   <ResultRow
-                    label="중개수수료"
-                    value={-result.saleProceeds.brokerageFee}
-                    negative
+                    label="실수령액"
+                    value={result.saleProceeds.netProceeds}
+                    bold
                   />
-                  <ResultRow
-                    label="양도소득세"
-                    value={-result.saleProceeds.capitalGainsTax}
-                    negative
-                  />
-                  <ResultRow
-                    label="대출 상환"
-                    value={-result.saleProceeds.loanRepayment}
-                    negative
-                  />
-                  <div className="border-t border-border pt-2">
-                    <ResultRow
-                      label="실수령액"
-                      value={result.saleProceeds.netProceeds}
-                      bold
-                    />
-                  </div>
                 </div>
               </div>
             </div>
+          </div>
 
-            {/* 양도세 상세 */}
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-semibold text-primary">양도세 상세</p>
-                <Badge
-                  variant={
-                    result.capitalGainsTaxDetail.isExempt ? "success" : "warning"
-                  }
-                >
-                  {result.capitalGainsTaxDetail.isExempt ? "비과세" : "과세"}
-                </Badge>
-              </div>
+          {/* 양도세 상세 */}
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold text-primary">양도세 상세</p>
+              <Badge
+                variant={
+                  result.capitalGainsTaxDetail.isExempt ? "success" : "warning"
+                }
+              >
+                {result.capitalGainsTaxDetail.isExempt ? "비과세" : "과세"}
+              </Badge>
+            </div>
 
-              <div className="rounded-[12px] bg-surface p-4">
-                <div className="flex flex-col gap-2">
-                  <ResultRow
-                    label="양도차익"
-                    value={result.capitalGainsTaxDetail.gain}
-                  />
+            <div className="rounded-[12px] bg-surface p-4">
+              <div className="flex flex-col gap-2">
+                <ResultRow
+                  label="양도차익"
+                  value={result.capitalGainsTaxDetail.gain}
+                />
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-secondary">비과세 판정</span>
+                  <span className="text-right text-xs text-secondary">
+                    {result.capitalGainsTaxDetail.exemptReason}
+                  </span>
+                </div>
+                {result.capitalGainsTaxDetail.longTermDeductionRate > 0 && (
                   <div className="flex items-center justify-between text-sm">
-                    <span className="text-secondary">비과세 판정</span>
-                    <span className="text-right text-xs text-secondary">
-                      {result.capitalGainsTaxDetail.exemptReason}
+                    <span className="text-secondary">
+                      장기보유공제 (
+                      {Math.round(
+                        result.capitalGainsTaxDetail.longTermDeductionRate * 100,
+                      )}
+                      %)
+                    </span>
+                    <span className="text-primary">
+                      -
+                      {formatToKoreanWon(
+                        result.capitalGainsTaxDetail.longTermDeduction,
+                      )}
                     </span>
                   </div>
-                  {result.capitalGainsTaxDetail.longTermDeductionRate > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-secondary">
-                        장기보유공제 (
-                        {Math.round(
-                          result.capitalGainsTaxDetail.longTermDeductionRate * 100,
-                        )}
-                        %)
-                      </span>
-                      <span className="text-primary">
-                        -
-                        {formatToKoreanWon(
-                          result.capitalGainsTaxDetail.longTermDeduction,
-                        )}
-                      </span>
-                    </div>
-                  )}
-                  {result.capitalGainsTaxDetail.taxRate > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-secondary">실효세율</span>
-                      <span className="text-primary">
-                        {result.capitalGainsTaxDetail.taxRate}%
-                      </span>
-                    </div>
-                  )}
-                  <div className="border-t border-border pt-2">
-                    <ResultRow
-                      label="양도세액"
-                      value={result.capitalGainsTaxDetail.taxAmount}
-                      bold
-                    />
+                )}
+                {result.capitalGainsTaxDetail.taxRate > 0 && (
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-secondary">실효세율</span>
+                    <span className="text-primary">
+                      {result.capitalGainsTaxDetail.taxRate}%
+                    </span>
                   </div>
+                )}
+                <div className="border-t border-border pt-2">
+                  <ResultRow
+                    label="양도세액"
+                    value={result.capitalGainsTaxDetail.taxAmount}
+                    bold
+                  />
                 </div>
               </div>
             </div>
+          </div>
 
-            {/* 새 구매력 히어로 */}
-            <div className="rounded-[12px] bg-accent-light px-4 py-5 text-center">
-              <p className="text-xs font-medium text-accent">새 집 구매 가능 금액</p>
-              <p className="mt-1 text-2xl font-bold text-accent">
-                {formatToKoreanWon(result.newPurchasingPower.totalBudget)}
-              </p>
-              <div className="mt-3 flex justify-center gap-4 text-xs text-secondary">
-                <span>
-                  자기자본{" "}
-                  {formatToKoreanWon(result.newPurchasingPower.ownCapital)}
-                </span>
-                <span>+</span>
-                <span>
-                  대출{" "}
-                  {formatToKoreanWon(result.newPurchasingPower.maxLoanAmount)}
-                </span>
-              </div>
-              <p className="mt-2 text-xs text-secondary">
-                월 상환액{" "}
-                <span className="font-semibold text-primary">
-                  {formatToKoreanWon(result.newPurchasingPower.monthlyPayment)}
-                </span>
-              </p>
-            </div>
-
-            {/* 경고 */}
-            {result.warnings.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <p className="text-sm font-semibold text-primary">참고사항</p>
-                <div className="rounded-[12px] bg-warning-light p-4">
-                  <ul className="flex flex-col gap-1.5">
-                    {result.warnings.map((warning, i) => (
-                      <li
-                        key={i}
-                        className="text-xs leading-relaxed text-warning"
-                      >
-                        {warning}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            )}
-
-            {/* 전제 조건 */}
-            <p className="text-[11px] leading-relaxed text-secondary">
-              * 시장금리 4.0% 기준 · LTV/DSR 규제 반영 · 양도세는 1세대 1주택
-              기준 간이 계산 · 실제 세액은 세무사 상담을 권장합니다
+          {/* 새 구매력 히어로 */}
+          <div className="rounded-[12px] bg-accent-light px-4 py-5 text-center">
+            <p className="text-xs font-medium text-accent">새 집 구매 가능 금액</p>
+            <p className="mt-1 text-2xl font-bold text-accent">
+              {formatToKoreanWon(result.newPurchasingPower.totalBudget)}
             </p>
-          </>
-        )}
-      </div>
-    </Card>
+            <div className="mt-3 flex justify-center gap-4 text-xs text-secondary">
+              <span>
+                자기자본{" "}
+                {formatToKoreanWon(result.newPurchasingPower.ownCapital)}
+              </span>
+              <span>+</span>
+              <span>
+                대출{" "}
+                {formatToKoreanWon(result.newPurchasingPower.maxLoanAmount)}
+              </span>
+            </div>
+            <p className="mt-2 text-xs text-secondary">
+              월 상환액{" "}
+              <span className="font-semibold text-primary">
+                {formatToKoreanWon(result.newPurchasingPower.monthlyPayment)}
+              </span>
+            </p>
+          </div>
+
+          {/* 경고 */}
+          {result.warnings.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-sm font-semibold text-primary">참고사항</p>
+              <div className="rounded-[12px] bg-warning-light p-4">
+                <ul className="flex flex-col gap-1.5">
+                  {result.warnings.map((warning, i) => (
+                    <li
+                      key={i}
+                      className="text-xs leading-relaxed text-warning"
+                    >
+                      {warning}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+
+          {/* 전제 조건 */}
+          <p className="text-[11px] leading-relaxed text-secondary">
+            * 시장금리 4.0% 기준 · LTV/DSR 규제 반영 · 양도세는 1세대 1주택
+            기준 간이 계산 · 실제 세액은 세무사 상담을 권장합니다
+          </p>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/src/store/useHousePinStore.ts
+++ b/src/store/useHousePinStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import type { AssetInput, HousePinStore } from '@/types';
 
 const initialAssetInput: AssetInput = {
@@ -15,45 +16,69 @@ const initialAssetInput: AssetInput = {
   transactionType: 'buy',
 };
 
-export const useHousePinStore = create<HousePinStore>((set) => ({
-  currentStep: 1,
-  setCurrentStep: (step) => set({ currentStep: step }),
-
-  assetInput: initialAssetInput,
-  setAssetInput: (input) =>
-    set((state) => ({
-      assetInput: { ...state.assetInput, ...input },
-    })),
-
-  loanResult: null,
-  setLoanResult: (result) => set({ loanResult: result }),
-
-  selectedRegions: [],
-  addRegion: (region) =>
-    set((state) => {
-      const exists = state.selectedRegions.some((r) => r.code === region.code);
-      if (exists) return state;
-      return { selectedRegions: [...state.selectedRegions, region] };
-    }),
-  removeRegion: (code) =>
-    set((state) => ({
-      selectedRegions: state.selectedRegions.filter((r) => r.code !== code),
-    })),
-  clearRegions: () => set({ selectedRegions: [] }),
-
-  properties: [],
-  setProperties: (properties) => set({ properties }),
-
-  liveListings: [],
-  setLiveListings: (listings) => set({ liveListings: listings }),
-
-  reset: () =>
-    set({
+export const useHousePinStore = create<HousePinStore>()(
+  persist(
+    (set) => ({
       currentStep: 1,
+      setCurrentStep: (step) => set({ currentStep: step }),
+
       assetInput: initialAssetInput,
+      setAssetInput: (input) =>
+        set((state) => ({
+          assetInput: { ...state.assetInput, ...input },
+        })),
+
       loanResult: null,
+      setLoanResult: (result) => set({ loanResult: result }),
+
       selectedRegions: [],
+      addRegion: (region) =>
+        set((state) => {
+          const exists = state.selectedRegions.some(
+            (r) => r.code === region.code,
+          );
+          if (exists) return state;
+          return { selectedRegions: [...state.selectedRegions, region] };
+        }),
+      removeRegion: (code) =>
+        set((state) => ({
+          selectedRegions: state.selectedRegions.filter(
+            (r) => r.code !== code,
+          ),
+        })),
+      clearRegions: () => set({ selectedRegions: [] }),
+
       properties: [],
+      setProperties: (properties) => set({ properties }),
+
       liveListings: [],
+      setLiveListings: (listings) => set({ liveListings: listings }),
+
+      reset: () =>
+        set({
+          currentStep: 1,
+          assetInput: initialAssetInput,
+          loanResult: null,
+          selectedRegions: [],
+          properties: [],
+          liveListings: [],
+        }),
+
+      _hasHydrated: false,
     }),
-}));
+    {
+      name: 'house-pin-store',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        assetInput: state.assetInput,
+        loanResult: state.loanResult,
+      }),
+      onRehydrateStorage: () => () => {
+        useHousePinStore.setState({ _hasHydrated: true });
+      },
+    },
+  ),
+);
+
+export const useHasHydrated = () =>
+  useHousePinStore((s) => s._hasHydrated);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,4 +84,6 @@ export interface HousePinStore {
   setLiveListings: (listings: import('./listing').LiveListing[]) => void;
 
   reset: () => void;
+
+  _hasHydrated: boolean;
 }


### PR DESCRIPTION
## Summary
결과 페이지(/result)에 7개 카드가 몰려있던 문제를 해결하는 Phase 1 리팩토링.
정보 밀도를 줄이면서 기능은 유지.

## Changes

### 1. PolicyLoan + PolicyBenefit 탭 통합
- `PolicyCard.tsx`: 두 카드를 "정책 대출" / "정책 혜택" 탭으로 통합
- `PolicyLoanContent.tsx`, `PolicyBenefitContent.tsx`: Card wrapper 없는 내용 컴포넌트

### 2. LoanSlider + BankComparisonTable 통합
- `LoanExplorer.tsx`: 대출 슬라이더 + 은행 비교를 하나의 카드로 통합
- 내부 상태 관리 (페이지에서 loanAmount state 제거)

### 3. CollapsibleCard 접기/펼치기
- `CollapsibleCard.tsx`: 재사용 가능 접기/펼치기 카드 컴포넌트
- 전세vs매매, 갈아타기 시뮬레이터: 기본 접힌 상태 (defaultOpen=false)
- ResizeObserver 기반 높이 애니메이션, chevron 회전

### 4. Zustand sessionStorage 영속화
- `assetInput`과 `loanResult`를 sessionStorage에 persist
- `_hasHydrated` 패턴으로 hydration 전 잘못된 리다이렉트 방지
- 매물 상세 페이지에도 hydration 가드 적용

## Before → After
```
Before (7개 카드 일렬):
AffordabilityCard
PolicyLoanCard
PolicyBenefitCard
LoanSlider
BankComparisonTable
ScenarioComparisonCard
UpgradeSimulatorCard

After (4개 + 2개 접힘):
AffordabilityCard          ← 항상 열림 (히어로)
PolicyCard (탭 통합)       ← 항상 열림
LoanExplorer (통합)        ← 항상 열림
▶ 전세 vs 매매 비교        ← 접힌 상태 (탭으로 펼침)
▶ 갈아타기 시뮬레이터      ← 접힌 상태 (탭으로 펼침)
```

## Test plan
- [x] TypeScript 빌드 에러 없음
- [x] 기존 테스트 569/571 통과 (기존 실패 2건 유지)
- [ ] /result 페이지 카드 렌더링 확인
- [ ] 접기/펼치기 애니메이션 동작 확인
- [ ] 새로고침 후 sessionStorage에서 데이터 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)