### PR TITLE
[Phase 2-4] 카카오 지오코딩 클라이언트 구현

### DIFF
--- a/backend/src/main/java/com/housepin/api/collector/geocode/GeocodeService.java
+++ b/backend/src/main/java/com/housepin/api/collector/geocode/GeocodeService.java
@@ -1,0 +1,139 @@
+package com.housepin.api.collector.geocode;
+
+import com.housepin.api.domain.common.Coordinates;
+import com.housepin.api.domain.common.GeocodeStatus;
+import com.housepin.api.domain.common.RegionCode;
+import com.housepin.api.domain.property.PropertyTrade;
+import com.housepin.api.domain.property.PropertyTradeRepository;
+import com.housepin.api.domain.region.Region;
+import com.housepin.api.domain.region.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * PENDING 상태의 매물 데이터에 좌표를 부여하는 지오코딩 서비스.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GeocodeService {
+
+    private final KakaoGeocodeClient geocodeClient;
+    private final KakaoGeocodeProperties properties;
+    private final PropertyTradeRepository propertyTradeRepository;
+    private final RegionRepository regionRepository;
+
+    /**
+     * PENDING 상태의 매물 데이터에 좌표를 부여한다.
+     *
+     * <ol>
+     *   <li>PENDING 상태 매물을 batchSize만큼 조회</li>
+     *   <li>같은 주소(시군구+동+지번) 중복 제거</li>
+     *   <li>유니크 주소에 대해 카카오 API 호출</li>
+     *   <li>결과를 해당 매물에 일괄 적용</li>
+     *   <li>실패 건은 geocode_status = FAILED로 업데이트</li>
+     * </ol>
+     *
+     * @return 성공 건수
+     */
+    @Transactional
+    public int geocodePendingProperties() {
+        List<PropertyTrade> pending = propertyTradeRepository
+                .findByGeocodeStatus(GeocodeStatus.PENDING, PageRequest.of(0, properties.batchSize()));
+
+        if (pending.isEmpty()) {
+            log.info("지오코딩 대상 없음");
+            return 0;
+        }
+
+        log.info("지오코딩 시작: {}건 대상", pending.size());
+
+        Map<String, List<PropertyTrade>> addressGroups = groupByAddress(pending);
+        log.info("유니크 주소 {}건에 대해 지오코딩 수행", addressGroups.size());
+
+        int successCount = 0;
+
+        for (Map.Entry<String, List<PropertyTrade>> entry : addressGroups.entrySet()) {
+            String address = entry.getKey();
+            List<PropertyTrade> trades = entry.getValue();
+
+            Coordinates coords = geocodeClient.searchAddress(address);
+
+            if (coords != null) {
+                trades.forEach(t -> t.updateGeocode(coords));
+                successCount += trades.size();
+            } else {
+                trades.forEach(PropertyTrade::markGeocodeFailed);
+                log.debug("지오코딩 실패: address={}, {}건", address, trades.size());
+            }
+
+            sleep(properties.requestDelayMs());
+        }
+
+        propertyTradeRepository.saveAll(pending);
+        log.info("지오코딩 완료: {}/{} 건 성공", successCount, pending.size());
+        return successCount;
+    }
+
+    /**
+     * 주소 문자열을 생성한다.
+     *
+     * @param sigungu 시군구명 (예: "강남구")
+     * @param dong    법정동 (예: "역삼동")
+     * @param jibun   지번 (예: "123")
+     * @return 조합된 주소 문자열 (예: "강남구 역삼동 123")
+     */
+    public String buildAddress(String sigungu, String dong, String jibun) {
+        return Stream.of(sigungu, dong, jibun)
+                .filter(part -> part != null && !part.isBlank())
+                .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * 매물 목록을 주소 기준으로 그룹핑한다.
+     * regionCode로 Region 테이블에서 시군구명을 조회하여 주소를 구성한다.
+     */
+    private Map<String, List<PropertyTrade>> groupByAddress(List<PropertyTrade> trades) {
+        // regionCode별로 시군구명을 캐싱하여 중복 조회 방지
+        Map<String, String> sigunguCache = new HashMap<>();
+
+        Map<String, List<PropertyTrade>> groups = new LinkedHashMap<>();
+
+        for (PropertyTrade trade : trades) {
+            String sigungu = sigunguCache.computeIfAbsent(
+                    trade.getRegionCode(),
+                    code -> regionRepository.findByCode(RegionCode.of(code))
+                            .map(Region::getSigungu)
+                            .orElse("")
+            );
+
+            String address = buildAddress(sigungu, trade.getDong(), trade.getJibun());
+
+            if (address.isBlank()) {
+                log.warn("주소 생성 불가: tradeId={}, regionCode={}", trade.getId(), trade.getRegionCode());
+                trade.markGeocodeFailed();
+                continue;
+            }
+
+            groups.computeIfAbsent(address, k -> new ArrayList<>()).add(trade);
+        }
+
+        return groups;
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("지오코딩 대기 중 인터럽트 발생");
+        }
+    }
+}

--- a/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeClient.java
+++ b/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeClient.java
@@ -1,0 +1,87 @@
+package com.housepin.api.collector.geocode;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.housepin.api.domain.common.Coordinates;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 카카오 주소 검색 API HTTP 클라이언트.
+ * 주소 문자열을 받아 위경도 좌표를 반환한다.
+ */
+@Component
+@Slf4j
+public class KakaoGeocodeClient {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public KakaoGeocodeClient(
+            @Qualifier("kakaoRestClient") RestClient restClient,
+            ObjectMapper objectMapper
+    ) {
+        this.restClient = restClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 주소를 검색하여 좌표를 반환한다.
+     * 결과가 없거나 오류 발생 시 null을 반환한다.
+     *
+     * @param query 검색할 주소 문자열 (예: "강남구 역삼동 123")
+     * @return 좌표 또는 null
+     */
+    public Coordinates searchAddress(String query) {
+        if (query == null || query.isBlank()) {
+            log.debug("지오코딩 쿼리가 비어있음");
+            return null;
+        }
+
+        try {
+            String json = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/v2/local/search/address.json")
+                            .queryParam("query", query)
+                            .build())
+                    .retrieve()
+                    .body(String.class);
+
+            if (json == null || json.isBlank()) {
+                log.warn("카카오 지오코딩 빈 응답: query={}", query);
+                return null;
+            }
+
+            KakaoAddressResponse response = objectMapper.readValue(json, KakaoAddressResponse.class);
+
+            if (response.documents() == null || response.documents().isEmpty()) {
+                log.debug("카카오 지오코딩 결과 없음: query={}", query);
+                return null;
+            }
+
+            KakaoDocument first = response.documents().get(0);
+            BigDecimal lat = new BigDecimal(first.y());
+            BigDecimal lng = new BigDecimal(first.x());
+
+            log.debug("카카오 지오코딩 성공: query={}, lat={}, lng={}", query, lat, lng);
+            return Coordinates.of(lat, lng);
+
+        } catch (Exception e) {
+            log.error("카카오 지오코딩 실패: query={}, error={}", query, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record KakaoAddressResponse(List<KakaoDocument> documents) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record KakaoDocument(String x, String y, String address_name) {
+    }
+}

--- a/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeConfig.java
+++ b/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeConfig.java
@@ -1,0 +1,28 @@
+package com.housepin.api.collector.geocode;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(KakaoGeocodeProperties.class)
+public class KakaoGeocodeConfig {
+
+    @Bean("kakaoRestClient")
+    public RestClient kakaoRestClient(KakaoGeocodeProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .defaultHeader("Authorization", "KakaoAK " + properties.restApiKey())
+                .requestFactory(clientHttpRequestFactory(properties))
+                .build();
+    }
+
+    private SimpleClientHttpRequestFactory clientHttpRequestFactory(KakaoGeocodeProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.timeoutSeconds() * 1000);
+        factory.setReadTimeout(properties.timeoutSeconds() * 1000);
+        return factory;
+    }
+}

--- a/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeProperties.java
+++ b/backend/src/main/java/com/housepin/api/collector/geocode/KakaoGeocodeProperties.java
@@ -1,0 +1,22 @@
+package com.housepin.api.collector.geocode;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao.geocode")
+public record KakaoGeocodeProperties(
+        String baseUrl,
+        String restApiKey,
+        int timeoutSeconds,
+        int batchSize,
+        int concurrency,
+        long requestDelayMs
+) {
+
+    public KakaoGeocodeProperties {
+        if (baseUrl == null) baseUrl = "https://dapi.kakao.com";
+        if (timeoutSeconds <= 0) timeoutSeconds = 5;
+        if (batchSize <= 0) batchSize = 100;
+        if (concurrency <= 0) concurrency = 5;
+        if (requestDelayMs <= 0) requestDelayMs = 100;
+    }
+}

--- a/backend/src/main/java/com/housepin/api/collector/molit/MolitClientConfig.java
+++ b/backend/src/main/java/com/housepin/api/collector/molit/MolitClientConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestClient;
 @EnableConfigurationProperties(MolitApiProperties.class)
 public class MolitClientConfig {
 
-    @Bean
+    @Bean("molitRestClient")
     public RestClient molitRestClient(MolitApiProperties properties) {
         return RestClient.builder()
                 .baseUrl(properties.baseUrl())

--- a/backend/src/main/java/com/housepin/api/domain/property/PropertyTradeRepository.java
+++ b/backend/src/main/java/com/housepin/api/domain/property/PropertyTradeRepository.java
@@ -1,6 +1,12 @@
 package com.housepin.api.domain.property;
 
+import com.housepin.api.domain.common.GeocodeStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PropertyTradeRepository extends JpaRepository<PropertyTrade, Long> {
+
+    List<PropertyTrade> findByGeocodeStatus(GeocodeStatus status, Pageable pageable);
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -13,6 +13,10 @@ molit:
   api:
     service-key: ${DATA_GO_KR_API_KEY:test-key}
 
+kakao:
+  geocode:
+    rest-api-key: ${KAKAO_REST_API_KEY:test-key}
+
 logging:
   level:
     com.housepin: DEBUG

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -11,6 +11,10 @@ molit:
   api:
     service-key: ${DATA_GO_KR_API_KEY}
 
+kakao:
+  geocode:
+    rest-api-key: ${KAKAO_REST_API_KEY}
+
 logging:
   level:
     com.housepin: INFO

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,14 @@ molit:
     max-retries: 3
     request-delay-ms: 200
 
+kakao:
+  geocode:
+    base-url: https://dapi.kakao.com
+    timeout-seconds: 5
+    batch-size: 100
+    concurrency: 5
+    request-delay-ms: 100
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/backend/src/test/java/com/housepin/api/collector/geocode/GeocodeServiceTest.java
+++ b/backend/src/test/java/com/housepin/api/collector/geocode/GeocodeServiceTest.java
@@ -1,0 +1,233 @@
+package com.housepin.api.collector.geocode;
+
+import com.housepin.api.domain.common.*;
+import com.housepin.api.domain.property.PropertyTrade;
+import com.housepin.api.domain.property.PropertyTradeRepository;
+import com.housepin.api.domain.region.Region;
+import com.housepin.api.domain.region.RegionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GeocodeServiceTest {
+
+    @Mock
+    private KakaoGeocodeClient geocodeClient;
+
+    @Mock
+    private KakaoGeocodeProperties properties;
+
+    @Mock
+    private PropertyTradeRepository propertyTradeRepository;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @InjectMocks
+    private GeocodeService geocodeService;
+
+    // ============================================================
+    // 헬퍼
+    // ============================================================
+
+    private PropertyTrade createTrade(String dong, String jibun) {
+        return PropertyTrade.create(
+                "11680", PropertyType.APARTMENT, TradeType.TRADE,
+                "테스트아파트", dong, jibun,
+                80000, new BigDecimal("84.97"), (short) 12, (short) 2015,
+                LocalDate.of(2024, 3, 15), "{}"
+        );
+    }
+
+    private void mockRegionLookup() {
+        Region region = mock(Region.class);
+        when(region.getSigungu()).thenReturn("강남구");
+        when(regionRepository.findByCode(any(RegionCode.class))).thenReturn(Optional.of(region));
+    }
+
+    // ============================================================
+    // 배치 지오코딩 테스트
+    // ============================================================
+
+    @Nested
+    @DisplayName("geocodePendingProperties - 배치 지오코딩")
+    class GeocodePendingPropertiesTest {
+
+        @Test
+        @DisplayName("PENDING 상태의 매물이 없으면 0을 반환하고 API를 호출하지 않는다")
+        void geocode_noPending_returnsZero() {
+            // given
+            when(properties.batchSize()).thenReturn(100);
+            when(propertyTradeRepository.findByGeocodeStatus(eq(GeocodeStatus.PENDING), any(Pageable.class)))
+                    .thenReturn(List.of());
+
+            // when
+            int result = geocodeService.geocodePendingProperties();
+
+            // then
+            assertThat(result).isEqualTo(0);
+            verify(geocodeClient, never()).searchAddress(anyString());
+        }
+
+        @Test
+        @DisplayName("3개 매물 중 2개가 고유 주소일 때 모두 성공하면 3을 반환한다")
+        void geocode_threeProperties_twoUniqueAddresses_returnsThree() {
+            // given
+            PropertyTrade trade1 = createTrade("역삼동", "123");
+            PropertyTrade trade2 = createTrade("역삼동", "123");
+            PropertyTrade trade3 = createTrade("서초동", "456");
+
+            when(properties.batchSize()).thenReturn(100);
+            when(properties.requestDelayMs()).thenReturn(0L);
+            when(propertyTradeRepository.findByGeocodeStatus(eq(GeocodeStatus.PENDING), any(Pageable.class)))
+                    .thenReturn(List.of(trade1, trade2, trade3));
+            mockRegionLookup();
+
+            Coordinates gangnamCoords = Coordinates.of(new BigDecimal("37.517"), new BigDecimal("127.047"));
+            Coordinates seochoCoords = Coordinates.of(new BigDecimal("37.483"), new BigDecimal("127.032"));
+
+            when(geocodeClient.searchAddress(contains("역삼동"))).thenReturn(gangnamCoords);
+            when(geocodeClient.searchAddress(contains("서초동"))).thenReturn(seochoCoords);
+            when(propertyTradeRepository.saveAll(anyList())).thenReturn(List.of());
+
+            // when
+            int result = geocodeService.geocodePendingProperties();
+
+            // then
+            assertThat(result).isEqualTo(3);
+            assertThat(trade1.getCoordinates()).isEqualTo(gangnamCoords);
+            assertThat(trade2.getCoordinates()).isEqualTo(gangnamCoords);
+            assertThat(trade3.getCoordinates()).isEqualTo(seochoCoords);
+        }
+
+        @Test
+        @DisplayName("첫 번째만 성공하면 1을 반환하고 두 번째는 실패 처리한다")
+        void geocode_partialFailure_returnsOne() {
+            // given
+            PropertyTrade trade1 = createTrade("역삼동", "123");
+            PropertyTrade trade2 = createTrade("서초동", "456");
+
+            when(properties.batchSize()).thenReturn(100);
+            when(properties.requestDelayMs()).thenReturn(0L);
+            when(propertyTradeRepository.findByGeocodeStatus(eq(GeocodeStatus.PENDING), any(Pageable.class)))
+                    .thenReturn(List.of(trade1, trade2));
+            mockRegionLookup();
+
+            when(geocodeClient.searchAddress(contains("역삼동")))
+                    .thenReturn(Coordinates.of(new BigDecimal("37.517"), new BigDecimal("127.047")));
+            when(geocodeClient.searchAddress(contains("서초동"))).thenReturn(null);
+            when(propertyTradeRepository.saveAll(anyList())).thenReturn(List.of());
+
+            // when
+            int result = geocodeService.geocodePendingProperties();
+
+            // then
+            assertThat(result).isEqualTo(1);
+            assertThat(trade2.getGeocodeStatus()).isEqualTo(GeocodeStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("모든 지오코딩이 실패하면 0을 반환한다")
+        void geocode_allFail_returnsZero() {
+            // given
+            PropertyTrade trade1 = createTrade("역삼동", "123");
+
+            when(properties.batchSize()).thenReturn(100);
+            when(properties.requestDelayMs()).thenReturn(0L);
+            when(propertyTradeRepository.findByGeocodeStatus(eq(GeocodeStatus.PENDING), any(Pageable.class)))
+                    .thenReturn(List.of(trade1));
+            mockRegionLookup();
+
+            when(geocodeClient.searchAddress(anyString())).thenReturn(null);
+            when(propertyTradeRepository.saveAll(anyList())).thenReturn(List.of());
+
+            // when
+            int result = geocodeService.geocodePendingProperties();
+
+            // then
+            assertThat(result).isEqualTo(0);
+            assertThat(trade1.getGeocodeStatus()).isEqualTo(GeocodeStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("동일 주소 5개 매물은 API를 1번만 호출한다")
+        void geocode_duplicateAddresses_callsApiOnce() {
+            // given
+            List<PropertyTrade> trades = List.of(
+                    createTrade("역삼동", "123"),
+                    createTrade("역삼동", "123"),
+                    createTrade("역삼동", "123"),
+                    createTrade("역삼동", "123"),
+                    createTrade("역삼동", "123")
+            );
+
+            when(properties.batchSize()).thenReturn(100);
+            when(properties.requestDelayMs()).thenReturn(0L);
+            when(propertyTradeRepository.findByGeocodeStatus(eq(GeocodeStatus.PENDING), any(Pageable.class)))
+                    .thenReturn(trades);
+            mockRegionLookup();
+
+            Coordinates coords = Coordinates.of(new BigDecimal("37.517"), new BigDecimal("127.047"));
+            when(geocodeClient.searchAddress(anyString())).thenReturn(coords);
+            when(propertyTradeRepository.saveAll(anyList())).thenReturn(List.of());
+
+            // when
+            int result = geocodeService.geocodePendingProperties();
+
+            // then
+            assertThat(result).isEqualTo(5);
+            verify(geocodeClient, times(1)).searchAddress(anyString());
+        }
+    }
+
+    // ============================================================
+    // buildAddress 테스트
+    // ============================================================
+
+    @Nested
+    @DisplayName("buildAddress - 주소 문자열 조합")
+    class BuildAddressTest {
+
+        @Test
+        @DisplayName("시군구, 동, 지번이 모두 있으면 전체 주소를 반환한다")
+        void buildAddress_allPresent_returnsFullAddress() {
+            assertThat(geocodeService.buildAddress("강남구", "역삼동", "123"))
+                    .isEqualTo("강남구 역삼동 123");
+        }
+
+        @Test
+        @DisplayName("지번이 비어 있으면 시군구 동까지만 반환한다")
+        void buildAddress_emptyJibun_omitsJibun() {
+            assertThat(geocodeService.buildAddress("강남구", "역삼동", ""))
+                    .isEqualTo("강남구 역삼동");
+        }
+
+        @Test
+        @DisplayName("모든 인자가 비어 있으면 빈 문자열을 반환한다")
+        void buildAddress_allEmpty_returnsEmpty() {
+            assertThat(geocodeService.buildAddress("", "", "")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null 지번은 빈 문자열과 동일하게 처리한다")
+        void buildAddress_nullJibun_treatsAsEmpty() {
+            assertThat(geocodeService.buildAddress("강남구", "역삼동", null))
+                    .isEqualTo("강남구 역삼동");
+        }
+    }
+}

--- a/backend/src/test/java/com/housepin/api/collector/geocode/KakaoGeocodeClientTest.java
+++ b/backend/src/test/java/com/housepin/api/collector/geocode/KakaoGeocodeClientTest.java
@@ -1,0 +1,139 @@
+package com.housepin.api.collector.geocode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.housepin.api.domain.common.Coordinates;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoGeocodeClientTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private RestClient.RequestHeadersUriSpec<?> requestHeadersUriSpec;
+
+    @Mock
+    private RestClient.RequestHeadersSpec<?> requestHeadersSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private KakaoGeocodeClient client;
+
+    private static final String SUCCESS_RESPONSE = """
+            {
+              "documents": [
+                {
+                  "address_name": "서울 강남구 역삼동 123",
+                  "x": "127.0473248",
+                  "y": "37.5172363"
+                }
+              ]
+            }
+            """;
+
+    private static final String EMPTY_DOCUMENTS_RESPONSE = """
+            {
+              "documents": []
+            }
+            """;
+
+    private static final String MULTIPLE_DOCUMENTS_RESPONSE = """
+            {
+              "documents": [
+                {
+                  "address_name": "서울 강남구 역삼동 123",
+                  "x": "127.0473248",
+                  "y": "37.5172363"
+                },
+                {
+                  "address_name": "서울 강남구 역삼동 456",
+                  "x": "127.0500000",
+                  "y": "37.5200000"
+                }
+              ]
+            }
+            """;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        client = new KakaoGeocodeClient(restClient, new ObjectMapper());
+
+        when(restClient.get()).thenReturn((RestClient.RequestHeadersUriSpec) requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(any(Function.class))).thenReturn((RestClient.RequestHeadersSpec) requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    @Test
+    @DisplayName("정상 응답 시 첫 번째 문서의 좌표를 반환한다")
+    void searchAddress_successResponse_returnsCoordinates() {
+        // Given
+        when(responseSpec.body(String.class)).thenReturn(SUCCESS_RESPONSE);
+
+        // When
+        Coordinates result = client.searchAddress("서울 강남구 역삼동 123");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getLat()).isEqualByComparingTo(new BigDecimal("37.5172363"));
+        assertThat(result.getLng()).isEqualByComparingTo(new BigDecimal("127.0473248"));
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없으면 null을 반환한다")
+    void searchAddress_emptyDocuments_returnsNull() {
+        // Given
+        when(responseSpec.body(String.class)).thenReturn(EMPTY_DOCUMENTS_RESPONSE);
+
+        // When
+        Coordinates result = client.searchAddress("존재하지 않는 주소");
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("API 호출 중 예외 발생 시 null을 반환한다")
+    void searchAddress_apiError_returnsNull() {
+        // Given
+        when(responseSpec.body(String.class))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        // When
+        Coordinates result = client.searchAddress("서울 강남구 역삼동 123");
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("여러 문서가 반환되면 첫 번째 문서의 좌표만 사용한다")
+    void searchAddress_multipleDocuments_usesFirstDocumentOnly() {
+        // Given
+        when(responseSpec.body(String.class)).thenReturn(MULTIPLE_DOCUMENTS_RESPONSE);
+
+        // When
+        Coordinates result = client.searchAddress("서울 강남구 역삼동");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getLat()).isEqualByComparingTo(new BigDecimal("37.5172363"));
+        assertThat(result.getLng()).isEqualByComparingTo(new BigDecimal("127.0473248"));
+    }
+}


### PR DESCRIPTION
## Summary
- 카카오 주소검색 API 클라이언트 구현 (주소 → 좌표 변환)
- 배치 지오코딩 서비스 (PENDING 매물 일괄 좌표 부여)
- 단위 테스트 13개 작성

## 주요 변경사항

### 신규 파일 (`collector/geocode/`)
| 파일 | 역할 |
|------|------|
| `KakaoGeocodeProperties` | API 설정 (baseUrl, restApiKey, batchSize 등) |
| `KakaoGeocodeConfig` | RestClient Bean (`@Qualifier("kakaoRestClient")`) |
| `KakaoGeocodeClient` | 카카오 주소검색 HTTP 클라이언트 |
| `GeocodeService` | 배치 지오코딩 비즈니스 로직 |

### 배치 지오코딩 핵심 로직
1. PENDING 상태 매물 batchSize만큼 조회
2. 같은 주소(시군구+동+지번) **중복 제거** → API 1회만 호출
3. Region 테이블에서 시군구명 조회 (regionCode → "강남구")
4. 성공 시 `updateGeocode(coords)`, 실패 시 `markGeocodeFailed()`
5. `saveAll()`로 일괄 저장

### 수정 파일
- `MolitClientConfig`: `@Bean("molitRestClient")` qualifier 추가 (Bean 충돌 방지)
- `PropertyTradeRepository`: `findByGeocodeStatus()` 쿼리 추가
- `application.yml`: kakao.geocode 설정 추가

### 테스트 (13개, 전부 통과)
- **KakaoGeocodeClientTest** (4개): 정상/빈결과/에러/다중문서
- **GeocodeServiceTest** (9개): 배치 성공/부분실패/전체실패/중복최적화 + buildAddress

## Test plan
- [x] `./gradlew compileJava` 빌드 성공
- [x] `./gradlew test --tests "com.housepin.api.collector.geocode.*"` 13개 통과
- [x] 기존 Molit 테스트 22개도 통과 확인

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)